### PR TITLE
Tune vLLM runtime defaults by model profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,21 @@ Recommended conventions:
 - `chore(...)` for maintenance that does not change behavior.
 
 For multi-line commit messages, preserve real newlines in the body. Do not use literal `\n` escape sequences.
+
+## Verification
+
+For changes that affect runtime startup, model serving, extraction behavior,
+Docker Compose, platform detection, or end-to-end workflows, verify the full
+local runtime path before opening or updating a pull request:
+
+```bash
+parsehawk restart
+just e2e
+```
+
+When feasible, run this verification on both supported local-runtime platforms:
+
+- macOS Apple Silicon, which uses vLLM Metal on the host
+- Linux with an NVIDIA GPU, which uses the Docker Compose vLLM runtime service
+
+If one platform is not available, say so explicitly in the PR or final summary.

--- a/README.md
+++ b/README.md
@@ -332,16 +332,24 @@ Current defaults:
 | vLLM package | `vllm==0.23.0` |
 | Linux runtime image | `vllm/vllm-openai:v0.23.0` |
 | Model | `numind/NuExtract3-W4A16` |
-| GPU memory utilization | `0.5` |
-| Max model length | `8192` by default, `32768` on larger Apple Silicon Macs |
+| GPU memory utilization | platform- and memory-tier specific |
+| Max model length | platform- and memory-tier specific |
+| Max concurrent sequences | platform- and memory-tier specific |
 | PDF render DPI | `170` |
 | PDF max pages | `25` |
+
+For known bundled models, ParseHawk chooses conservative runtime defaults from
+the detected platform and memory tier. Apple Silicon uses unified memory; Linux
+uses NVIDIA GPU VRAM. These defaults favor reliable local startup over maximum
+throughput. Increase the context length, memory utilization, or concurrent
+sequence limit manually if you are running on a larger machine.
 
 Common overrides:
 
 ```bash
 PARSEHAWK_VLLM_MAX_MODEL_LEN=16384 parsehawk start
 PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION=0.6 parsehawk start
+PARSEHAWK_VLLM_MAX_NUM_SEQS=4 parsehawk start
 PARSEHAWK_VLLM_MODEL=numind/NuExtract3-W4A16 parsehawk start
 PARSEHAWK_VLLM_IMAGE=vllm/vllm-openai:v0.23.0 parsehawk start
 ```
@@ -359,9 +367,9 @@ ParseHawk uses Pydantic settings. Common environment variables:
 | `PARSEHAWK_INFERENCE_ENGINE` | `none` | API/worker inference engine. `parsehawk start` sets this to `vllm` when a runtime is configured. |
 | `PARSEHAWK_VLLM_BASE_URL` | `http://127.0.0.1:8080/v1` | OpenAI-compatible model runtime URL. |
 | `PARSEHAWK_VLLM_MODEL` | `numind/NuExtract3-W4A16` | Model name sent to the runtime. |
-| `PARSEHAWK_VLLM_MAX_MODEL_LEN` | platform-specific | vLLM context length. Overrides the automatic local default. |
-| `PARSEHAWK_VLLM_MAX_NUM_SEQS` | `128` | Linux vLLM maximum concurrent decode sequences. |
-| `PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION` | `0.5` | vLLM memory reservation fraction. |
+| `PARSEHAWK_VLLM_MAX_MODEL_LEN` | platform-specific | vLLM context length. Overrides the automatic runtime-profile default. |
+| `PARSEHAWK_VLLM_MAX_NUM_SEQS` | platform-specific | vLLM maximum concurrent decode sequences. Overrides the automatic runtime-profile default. |
+| `PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION` | platform-specific | vLLM memory reservation fraction. On Apple Silicon this is also mapped to `VLLM_METAL_MEMORY_FRACTION`. |
 | `PARSEHAWK_VLLM_IMAGE` | `vllm/vllm-openai:v0.23.0` | Linux Docker runtime image. |
 | `PARSEHAWK_VLLM_CACHE_HOME` | `~/.cache/vllm` | Linux host cache for vLLM compile artifacts. |
 | `PARSEHAWK_PDF_MAX_PAGES` | `25` | Maximum PDF pages rendered for one extraction. |

--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -465,7 +465,9 @@ describe("App run workflow", () => {
     expect((await screen.findAllByText("receipt.md")).length).toBeGreaterThan(0);
     expect(await screen.findByText("Uploaded receipt text")).toBeInTheDocument();
 
-    await userEvent.click(await screen.findByText("job_text"));
+    const textJobRow = (await screen.findByLabelText("Copy job ID job_text")).closest("[role='button']");
+    expect(textJobRow).not.toBeNull();
+    await userEvent.click(textJobRow!);
 
     expect(await screen.findByText("Text input")).toBeInTheDocument();
     expect(screen.getAllByText("Archived inline text").length).toBeGreaterThan(0);

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -9,3 +9,4 @@ class ResizeObserverMock {
 globalThis.ResizeObserver = ResizeObserverMock;
 globalThis.scrollTo = () => {};
 Element.prototype.scrollTo = () => {};
+document.execCommand = () => true;

--- a/docker/docker-compose.linux.yml
+++ b/docker/docker-compose.linux.yml
@@ -24,7 +24,7 @@ services:
       - --max-model-len
       - ${PARSEHAWK_VLLM_MAX_MODEL_LEN:-8192}
       - --max-num-seqs
-      - ${PARSEHAWK_VLLM_MAX_NUM_SEQS:-128}
+      - ${PARSEHAWK_VLLM_MAX_NUM_SEQS:-1}
       - --structured-outputs-config.enable_in_reasoning=True
     environment:
       HF_HOME: /root/.cache/huggingface

--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -21,10 +21,17 @@ from typing import Any
 
 from parsehawk.config import (
     DEFAULT_DATA_DIR,
+    DEFAULT_VLLM_GPU_MEMORY_UTILIZATION,
     DEFAULT_VLLM_MAX_MODEL_LEN,
+    DEFAULT_VLLM_MAX_NUM_SEQS,
     DEFAULT_VLLM_MODEL,
     Settings,
     default_inference_engine,
+)
+from parsehawk.model_profiles import (
+    RuntimePlatform,
+    RuntimeProfileDefaults,
+    runtime_profile_defaults,
 )
 from parsehawk.server.runtime.vllm_env import (
     ensure_vllm_metal_venv,
@@ -33,8 +40,6 @@ from parsehawk.server.runtime.vllm_env import (
 )
 
 UNSUPPORTED_RUNTIME = "unsupported"
-NUEXTRACT3_W4A16_HIGH_MEMORY_THRESHOLD_BYTES = 32_000_000_000
-NUEXTRACT3_W4A16_HIGH_MEMORY_MAX_MODEL_LEN = 32768
 
 
 def _default_runtime() -> str:
@@ -66,22 +71,70 @@ def _system_memory_bytes() -> int | None:
     return pages * page_size
 
 
-def _default_vllm_max_model_len_for_host(model: str) -> int:
-    if model.lower() != DEFAULT_VLLM_MODEL.lower():
-        return DEFAULT_VLLM_MAX_MODEL_LEN
-    if not _is_macos_apple_silicon():
-        return DEFAULT_VLLM_MAX_MODEL_LEN
-    memory_bytes = _system_memory_bytes()
-    if memory_bytes is not None and memory_bytes >= NUEXTRACT3_W4A16_HIGH_MEMORY_THRESHOLD_BYTES:
-        return NUEXTRACT3_W4A16_HIGH_MEMORY_MAX_MODEL_LEN
-    return DEFAULT_VLLM_MAX_MODEL_LEN
+def _nvidia_gpu_memory_bytes() -> int | None:
+    if shutil.which("nvidia-smi") is None:
+        return None
+    try:
+        result = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=memory.total",
+                "--format=csv,noheader,nounits",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    memory_mib: list[int] = []
+    for line in result.stdout.splitlines():
+        try:
+            memory_mib.append(int(line.strip()))
+        except ValueError:
+            continue
+    if not memory_mib:
+        return None
+    return max(memory_mib) * 1024 * 1024
+
+
+def _runtime_profile_context() -> tuple[RuntimePlatform, int | None] | None:
+    if _is_macos_apple_silicon():
+        return RuntimePlatform.MACOS_APPLE_SILICON, _system_memory_bytes()
+    if _is_linux_x86_64():
+        return RuntimePlatform.LINUX_NVIDIA, _nvidia_gpu_memory_bytes()
+    return None
 
 
 def _resolve_vllm_settings(settings: Settings, *, model: str) -> Settings:
-    if os.getenv("PARSEHAWK_VLLM_MAX_MODEL_LEN") is not None:
+    context = _runtime_profile_context()
+    if context is None:
+        return settings
+    platform, memory_bytes = context
+    defaults = runtime_profile_defaults(
+        model=model,
+        platform=platform,
+        memory_bytes=memory_bytes,
+        fallback=RuntimeProfileDefaults(
+            max_model_len=DEFAULT_VLLM_MAX_MODEL_LEN,
+            gpu_memory_utilization=DEFAULT_VLLM_GPU_MEMORY_UTILIZATION,
+            max_num_seqs=DEFAULT_VLLM_MAX_NUM_SEQS,
+        ),
+    )
+    update: dict[str, int | float] = {}
+    if os.getenv("PARSEHAWK_VLLM_MAX_MODEL_LEN") is None:
+        update["vllm_max_model_len"] = defaults.max_model_len
+    if os.getenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION") is None:
+        update["vllm_gpu_memory_utilization"] = defaults.gpu_memory_utilization
+    if os.getenv("PARSEHAWK_VLLM_MAX_NUM_SEQS") is None:
+        update["vllm_max_num_seqs"] = defaults.max_num_seqs
+    if not update:
         return settings
     return settings.model_copy(
-        update={"vllm_max_model_len": _default_vllm_max_model_len_for_host(model)}
+        update=update,
     )
 
 
@@ -142,6 +195,8 @@ def _vllm_runtime_command(
         str(settings.vllm_gpu_memory_utilization),
         "--max-model-len",
         str(settings.vllm_max_model_len),
+        "--max-num-seqs",
+        str(settings.vllm_max_num_seqs),
         "--structured-outputs-config.enable_in_reasoning=True",
     ]
     if settings.vllm_enable_mtp:
@@ -483,6 +538,7 @@ def dev(args: argparse.Namespace) -> None:
         _progress(
             "Model Runtime limits: "
             f"max_model_len={runtime_settings.vllm_max_model_len}, "
+            f"max_num_seqs={runtime_settings.vllm_max_num_seqs}, "
             f"gpu_memory_utilization={runtime_settings.vllm_gpu_memory_utilization}"
         )
         runtime_cmd = _vllm_runtime_command(
@@ -685,6 +741,7 @@ def start_docker(args: argparse.Namespace) -> None:
         _progress(
             "Model Runtime limits: "
             f"max_model_len={runtime_settings.vllm_max_model_len}, "
+            f"max_num_seqs={runtime_settings.vllm_max_num_seqs}, "
             f"gpu_memory_utilization={runtime_settings.vllm_gpu_memory_utilization}"
         )
         if _is_macos_apple_silicon():
@@ -1217,6 +1274,7 @@ def _compose_env(
             "PARSEHAWK_RUNTIME_PORT": str(args.runtime_port),
             "PARSEHAWK_VLLM_MODEL": model,
             "PARSEHAWK_VLLM_MAX_MODEL_LEN": str(settings.vllm_max_model_len),
+            "PARSEHAWK_VLLM_MAX_NUM_SEQS": str(settings.vllm_max_num_seqs),
             "PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION": str(settings.vllm_gpu_memory_utilization),
             "PARSEHAWK_PDF_MAX_PAGES": str(settings.pdf_max_pages),
             "PARSEHAWK_HF_HOME": str(Path.home() / ".cache" / "huggingface"),

--- a/src/parsehawk/config.py
+++ b/src/parsehawk/config.py
@@ -12,6 +12,7 @@ DEFAULT_MODEL = "numind/NuExtract3-W4A16"
 DEFAULT_VLLM_MODEL = DEFAULT_MODEL
 DEFAULT_VLLM_MAX_MODEL_LEN = 8192
 DEFAULT_VLLM_GPU_MEMORY_UTILIZATION = 0.5
+DEFAULT_VLLM_MAX_NUM_SEQS = 1
 DEFAULT_VLLM_PIP_SPEC = "vllm==0.23.0"
 DEFAULT_VLLM_PYTHON_VERSION = "3.12"
 DEFAULT_NUEXTRACT_KEEP_ALIVE_SECONDS = 300
@@ -52,6 +53,7 @@ class Settings(BaseSettings):
     vllm_temperature: float = Field(default=0.2, ge=0)
     vllm_timeout_seconds: int = Field(default=600, ge=1)
     vllm_max_model_len: int = Field(default=DEFAULT_VLLM_MAX_MODEL_LEN, ge=1)
+    vllm_max_num_seqs: int = Field(default=DEFAULT_VLLM_MAX_NUM_SEQS, ge=1)
     vllm_gpu_memory_utilization: float = Field(
         default=DEFAULT_VLLM_GPU_MEMORY_UTILIZATION,
         gt=0,

--- a/src/parsehawk/model_profiles.py
+++ b/src/parsehawk/model_profiles.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from parsehawk.config import DEFAULT_VLLM_MODEL
+
+
+class RuntimePlatform(StrEnum):
+    MACOS_APPLE_SILICON = "macos-apple-silicon"
+    LINUX_NVIDIA = "linux-nvidia"
+
+
+@dataclass(frozen=True)
+class RuntimeTier:
+    min_memory_bytes: int
+    max_model_len: int
+    gpu_memory_utilization: float
+    max_num_seqs: int
+
+
+@dataclass(frozen=True)
+class RuntimeProfileDefaults:
+    max_model_len: int
+    gpu_memory_utilization: float
+    max_num_seqs: int
+
+
+@dataclass(frozen=True)
+class ModelRuntimeProfile:
+    model: str
+    tiers_by_platform: dict[RuntimePlatform, tuple[RuntimeTier, ...]]
+
+    def defaults_for(
+        self,
+        *,
+        platform: RuntimePlatform,
+        memory_bytes: int | None,
+        fallback: RuntimeProfileDefaults,
+    ) -> RuntimeProfileDefaults:
+        tiers = self.tiers_by_platform.get(platform)
+        if not tiers:
+            return fallback
+
+        if memory_bytes is None:
+            tier = tiers[0]
+        else:
+            tier = max(
+                (tier for tier in tiers if memory_bytes >= tier.min_memory_bytes),
+                key=lambda tier: tier.min_memory_bytes,
+                default=tiers[0],
+            )
+
+        return RuntimeProfileDefaults(
+            max_model_len=tier.max_model_len,
+            gpu_memory_utilization=tier.gpu_memory_utilization,
+            max_num_seqs=tier.max_num_seqs,
+        )
+
+
+GIB = 1024**3
+
+
+DEFAULT_MODEL_RUNTIME_PROFILE = ModelRuntimeProfile(
+    model=DEFAULT_VLLM_MODEL,
+    tiers_by_platform={
+        RuntimePlatform.MACOS_APPLE_SILICON: (
+            RuntimeTier(
+                min_memory_bytes=0,
+                max_model_len=8192,
+                gpu_memory_utilization=0.70,
+                max_num_seqs=1,
+            ),
+            RuntimeTier(
+                min_memory_bytes=32 * GIB,
+                max_model_len=32768,
+                gpu_memory_utilization=0.50,
+                max_num_seqs=4,
+            ),
+        ),
+        RuntimePlatform.LINUX_NVIDIA: (
+            RuntimeTier(
+                min_memory_bytes=0,
+                max_model_len=8192,
+                gpu_memory_utilization=0.90,
+                max_num_seqs=1,
+            ),
+            RuntimeTier(
+                min_memory_bytes=16 * GIB,
+                max_model_len=16384,
+                gpu_memory_utilization=0.85,
+                max_num_seqs=4,
+            ),
+            RuntimeTier(
+                min_memory_bytes=32 * GIB,
+                max_model_len=32768,
+                gpu_memory_utilization=0.75,
+                max_num_seqs=8,
+            ),
+        ),
+    },
+)
+
+MODEL_RUNTIME_PROFILES = {
+    DEFAULT_MODEL_RUNTIME_PROFILE.model.lower(): DEFAULT_MODEL_RUNTIME_PROFILE
+}
+
+
+def runtime_profile_defaults(
+    *,
+    model: str,
+    platform: RuntimePlatform,
+    memory_bytes: int | None,
+    fallback: RuntimeProfileDefaults,
+) -> RuntimeProfileDefaults:
+    profile = MODEL_RUNTIME_PROFILES.get(model.lower())
+    if profile is None:
+        return fallback
+    return profile.defaults_for(platform=platform, memory_bytes=memory_bytes, fallback=fallback)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -479,6 +479,7 @@ def test_dev_uses_settings_defaults_for_runtime_process(
     assert runtime_cmd[runtime_cmd.index("--model") + 1] == "model-from-env"
     assert runtime_cmd[runtime_cmd.index("--gpu-memory-utilization") + 1] == "0.5"
     assert runtime_cmd[runtime_cmd.index("--max-model-len") + 1] == "8192"
+    assert runtime_cmd[runtime_cmd.index("--max-num-seqs") + 1] == "1"
     assert spawned[0]["env"]["VLLM_USE_FLASHINFER_SAMPLER"] == "0"
     assert spawned[0]["env"]["VLLM_METAL_MEMORY_FRACTION"] == "0.5"
     assert "--no-use-colors" in spawned[1]["cmd"]
@@ -530,6 +531,7 @@ def test_dev_launches_vllm_runtime_when_selected(
     assert runtime_cmd[runtime_cmd.index("--reasoning-parser") + 1] == "qwen3"
     assert runtime_cmd[runtime_cmd.index("--gpu-memory-utilization") + 1] == "0.5"
     assert runtime_cmd[runtime_cmd.index("--max-model-len") + 1] == "8192"
+    assert runtime_cmd[runtime_cmd.index("--max-num-seqs") + 1] == "1"
     assert "--structured-outputs-config.enable_in_reasoning=True" in runtime_cmd
     assert spawned[0]["env"]["VLLM_USE_FLASHINFER_SAMPLER"] == "0"
     api_env = spawned[1]["env"]
@@ -547,40 +549,75 @@ def test_default_runtime_selects_per_platform(monkeypatch: pytest.MonkeyPatch) -
     assert cli._default_runtime() == cli.UNSUPPORTED_RUNTIME
 
 
-def test_vllm_max_model_len_defaults_to_memory_tier(
+def test_vllm_settings_default_to_macos_memory_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("PARSEHAWK_VLLM_MAX_MODEL_LEN", raising=False)
+    monkeypatch.delenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION", raising=False)
+    monkeypatch.delenv("PARSEHAWK_VLLM_MAX_NUM_SEQS", raising=False)
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
     settings = cli.Settings()
 
     monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 36_000_000_000)
-    assert (
-        cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16").vllm_max_model_len
-        == 32768
-    )
+    resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
+    assert resolved.vllm_max_model_len == 32768
+    assert resolved.vllm_gpu_memory_utilization == 0.5
+    assert resolved.vllm_max_num_seqs == 4
 
     monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 18_000_000_000)
-    assert (
-        cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16").vllm_max_model_len
-        == 8192
-    )
+    resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
+    assert resolved.vllm_max_model_len == 8192
+    assert resolved.vllm_gpu_memory_utilization == 0.7
+    assert resolved.vllm_max_num_seqs == 1
 
 
-def test_vllm_max_model_len_env_override_wins(
+def test_vllm_settings_default_to_linux_vram_tier(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PARSEHAWK_VLLM_MAX_MODEL_LEN", raising=False)
+    monkeypatch.delenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION", raising=False)
+    monkeypatch.delenv("PARSEHAWK_VLLM_MAX_NUM_SEQS", raising=False)
+    monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    settings = cli.Settings()
+
+    monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 12 * 1024**3)
+    resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
+    assert resolved.vllm_max_model_len == 8192
+    assert resolved.vllm_gpu_memory_utilization == 0.9
+    assert resolved.vllm_max_num_seqs == 1
+
+    monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 24 * 1024**3)
+    resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
+    assert resolved.vllm_max_model_len == 16384
+    assert resolved.vllm_gpu_memory_utilization == 0.85
+    assert resolved.vllm_max_num_seqs == 4
+
+    monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 48 * 1024**3)
+    resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
+    assert resolved.vllm_max_model_len == 32768
+    assert resolved.vllm_gpu_memory_utilization == 0.75
+    assert resolved.vllm_max_num_seqs == 8
+
+
+def test_vllm_settings_env_overrides_win(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("PARSEHAWK_VLLM_MAX_MODEL_LEN", "16384")
+    monkeypatch.setenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION", "0.6")
+    monkeypatch.setenv("PARSEHAWK_VLLM_MAX_NUM_SEQS", "2")
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
     monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 36_000_000_000)
 
-    assert (
-        cli._resolve_vllm_settings(
-            cli.Settings.from_env(),
-            model="numind/NuExtract3-W4A16",
-        ).vllm_max_model_len
-        == 16384
+    resolved = cli._resolve_vllm_settings(
+        cli.Settings.from_env(),
+        model="numind/NuExtract3-W4A16",
     )
+    assert resolved.vllm_max_model_len == 16384
+    assert resolved.vllm_gpu_memory_utilization == 0.6
+    assert resolved.vllm_max_num_seqs == 2
 
 
 def test_platform_dependencies_skip_runtime_none(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -803,6 +840,7 @@ def test_start_linux_vllm_uses_internal_runtime_port(
     monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
     monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 24 * 1024**3)
     monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
     monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
@@ -821,6 +859,9 @@ def test_start_linux_vllm_uses_internal_runtime_port(
     assert compose_ups[0]["env"]["PARSEHAWK_RUNTIME_PORT"] == "18080"
     assert compose_ups[0]["env"]["PARSEHAWK_INFERENCE_ENGINE"] == "vllm"
     assert compose_ups[0]["env"]["PARSEHAWK_VLLM_BASE_URL"] == "http://runtime:8080/v1"
+    assert compose_ups[0]["env"]["PARSEHAWK_VLLM_MAX_MODEL_LEN"] == "16384"
+    assert compose_ups[0]["env"]["PARSEHAWK_VLLM_MAX_NUM_SEQS"] == "4"
+    assert compose_ups[0]["env"]["PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION"] == "0.85"
     assert runtime_health_urls == ["http://127.0.0.1:18080/health"]
     state = cli._load_state(data_dir / "parsehawk-state.json")
     assert state.runtime_url == "http://127.0.0.1:18080/v1"

--- a/tests/unit/test_model_profiles.py
+++ b/tests/unit/test_model_profiles.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from parsehawk.model_profiles import (
+    GIB,
+    RuntimePlatform,
+    RuntimeProfileDefaults,
+    runtime_profile_defaults,
+)
+
+
+def test_known_model_resolves_platform_memory_tier() -> None:
+    defaults = runtime_profile_defaults(
+        model="numind/NuExtract3-W4A16",
+        platform=RuntimePlatform.LINUX_NVIDIA,
+        memory_bytes=24 * GIB,
+        fallback=RuntimeProfileDefaults(
+            max_model_len=8192,
+            gpu_memory_utilization=0.5,
+            max_num_seqs=1,
+        ),
+    )
+
+    assert defaults.max_model_len == 16384
+    assert defaults.gpu_memory_utilization == 0.85
+    assert defaults.max_num_seqs == 4
+
+
+def test_unknown_model_uses_fallback_defaults() -> None:
+    defaults = runtime_profile_defaults(
+        model="custom/model",
+        platform=RuntimePlatform.MACOS_APPLE_SILICON,
+        memory_bytes=64 * GIB,
+        fallback=RuntimeProfileDefaults(
+            max_model_len=8192,
+            gpu_memory_utilization=0.5,
+            max_num_seqs=1,
+        ),
+    )
+
+    assert defaults == RuntimeProfileDefaults(
+        max_model_len=8192,
+        gpu_memory_utilization=0.5,
+        max_num_seqs=1,
+    )


### PR DESCRIPTION
## Summary

- Add model runtime profiles for the bundled `numind/NuExtract3-W4A16` model.
- Resolve conservative vLLM defaults from platform memory tiers:
  - Apple Silicon uses unified memory.
  - Linux NVIDIA uses detected GPU VRAM from `nvidia-smi`.
- Apply profile defaults only when users have not set explicit env overrides.
- Pass `--max-num-seqs` through local vLLM launches and Linux Docker runtime configuration.
- Update README runtime defaults/override documentation.
- Harden the web test setup/history-row test so commit hooks remain deterministic.

Closes #6.

## Validation

- `uv run pytest`
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web test`
- pre-commit hooks during commit: ruff format/check, ty, unit tests, web typecheck, web tests

## Runtime Verification

macOS Apple Silicon:

- `uv run parsehawk restart`
- confirmed resolved limits: `max_model_len=32768`, `max_num_seqs=4`, `gpu_memory_utilization=0.5`
- `just e2e` -> `17 passed in 47.50s`

Linux NVIDIA L4 (`23034 MiB` VRAM):

- `/home/bene/.local/bin/uv run parsehawk restart`
- confirmed resolved limits: `max_model_len=16384`, `max_num_seqs=4`, `gpu_memory_utilization=0.85`
- vLLM reported `Available KV cache memory: 11.78 GiB`
- `/home/bene/.local/bin/uv run pytest --no-cov -m e2e tests/e2e` -> `17 passed in 23.58s`
