### PR TITLE
docs(readme): add status badges to README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/parsehawk/parsehawk/releases"><img src="https://img.shields.io/github/v/release/parsehawk/parsehawk?sort=semver" alt="Latest release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License: Apache 2.0"></a>
+  <a href="pyproject.toml"><img src="https://img.shields.io/badge/python-3.11%20%7C%203.12-blue.svg" alt="Python 3.11 | 3.12"></a>
+  <img src="https://img.shields.io/badge/platform-macOS%20%C2%B7%20Linux-lightgrey.svg" alt="Platform: macOS · Linux">
+  <a href="https://github.com/astral-sh/ruff"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json" alt="Linted with Ruff"></a>
+  <img src="https://img.shields.io/badge/100%25%20local-by%20default-2ea44f.svg" alt="100% local by default">
+  <a href="https://github.com/parsehawk/parsehawk/stargazers"><img src="https://img.shields.io/github/stars/parsehawk/parsehawk?style=social" alt="GitHub stars"></a>
+</p>
+
+<p align="center">
   <a href="#quickstart">Quickstart</a> ·
   <a href="#first-extraction">First extraction</a> ·
   <a href="#api-cli-and-web-ui">API, CLI, and Web UI</a> ·


### PR DESCRIPTION
## What

Adds a centered shields.io badge row to the README header, under the tagline and above the nav links.

The row (8 badges): **Latest release** · **License: Apache 2.0** · **Python 3.11 | 3.12** · **Platform: macOS · Linux** · **Linted with Ruff** · **100% local by default** · **GitHub stars**.

## Why

Closes #7, which asks for README badges (the issue comment specifically calls out an Apache 2.0 license badge and points at the xinity-ai repo for inspiration).

The header previously gave no at-a-glance signals for release, license, supported runtimes, code quality, or the project's local-first promise — a reader had to scroll into the body to learn any of it.

## Notes for the reviewer

Every badge is accurate to the repo as it stands today, and each badge URL was verified to return HTTP 200 before committing:

| Badge | Backed by |
|---|---|
| Latest release | tagged releases (`v0.1.1` via semver sort), links to `/releases` |
| License: Apache 2.0 | `license = "Apache-2.0"` in pyproject, links to `LICENSE` |
| Python 3.11 \| 3.12 | `requires-python = ">=3.11,<3.13"` |
| Platform: macOS · Linux | Requirements section |
| Linted with Ruff | `ruff` dev dependency + `[tool.ruff]` config; official Astral endpoint badge |
| 100% local by default | the project's core tagline (echoes the xinity-ai themed badges) |
| GitHub stars | live count, links to stargazers |

Deliberately **omitted**:
- **CI / build status** — no `.github/workflows` exists yet, so it would render broken.
- **PyPI** — `parsehawk` is not published to PyPI (404).
- **Coverage** — `pytest-cov` is present but no coverage service is wired up.

Docs-only change; no code or behavior affected.

Closes #7