### PR TITLE
fix(cli): stabilize local checks

### DIFF
--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -1039,7 +1039,13 @@ def config_command(args: argparse.Namespace) -> None:
 
 
 def doctor(args: argparse.Namespace) -> None:
-    config = load_cli_config(apply_env=True)
+    config = load_cli_config(apply_env=False)
+    for key, env_name in CONFIG_ENV_OVERRIDES.items():
+        if key == "data.dir":
+            continue
+        env_value = os.getenv(env_name)
+        if env_value:
+            config[key] = env_value
     api_url = args.api_url or config["server.url"]
     web_url = args.web_url or config["web.url"]
     runtime_url = args.runtime_url or config["runtime.url"]

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -501,6 +501,7 @@ def test_dev_launches_vllm_runtime_when_selected(
     monkeypatch.setenv("PARSEHAWK_VLLM_MODEL", "numind/NuExtract3-W4A16")
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
+    monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 24 * 1024**3)
     monkeypatch.setattr(
         cli, "ensure_vllm_venv", lambda *args, **kwargs: Path("/fake/vllm/bin/python")
     )
@@ -529,9 +530,9 @@ def test_dev_launches_vllm_runtime_when_selected(
     assert "vllm.entrypoints.openai.api_server" in runtime_cmd
     assert runtime_cmd[runtime_cmd.index("--model") + 1] == "numind/NuExtract3-W4A16"
     assert runtime_cmd[runtime_cmd.index("--reasoning-parser") + 1] == "qwen3"
-    assert runtime_cmd[runtime_cmd.index("--gpu-memory-utilization") + 1] == "0.5"
-    assert runtime_cmd[runtime_cmd.index("--max-model-len") + 1] == "8192"
-    assert runtime_cmd[runtime_cmd.index("--max-num-seqs") + 1] == "1"
+    assert runtime_cmd[runtime_cmd.index("--gpu-memory-utilization") + 1] == "0.85"
+    assert runtime_cmd[runtime_cmd.index("--max-model-len") + 1] == "16384"
+    assert runtime_cmd[runtime_cmd.index("--max-num-seqs") + 1] == "4"
     assert "--structured-outputs-config.enable_in_reasoning=True" in runtime_cmd
     assert spawned[0]["env"]["VLLM_USE_FLASHINFER_SAMPLER"] == "0"
     api_env = spawned[1]["env"]


### PR DESCRIPTION
Doctor should honor the persisted data directory when invoked without an explicit --data-dir instead of being overwritten by the justfile's default PARSEHAWK_DATA_DIR export. The Linux vLLM launch test now matches the platform profile defaults used by the CLI.

Closes #25 