### PR TITLE
fix(test): make vllm launch profile deterministic

### DIFF
--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -500,6 +500,7 @@ def test_dev_launches_vllm_runtime_when_selected(
     monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
     monkeypatch.setenv("PARSEHAWK_VLLM_MODEL", "numind/NuExtract3-W4A16")
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 24 * 1024**3)
     monkeypatch.setattr(


### PR DESCRIPTION
The launch test simulates a Linux NVIDIA runtime profile, so it should stub the Linux platform probe as well as GPU presence and VRAM. This keeps the expected vLLM limits independent of the host OS running the tests.

Relates to #26 