### PR TITLE
fix(cli): remember data dir for status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .coverage
 data/
 examples/
+example-applications/
 node_modules/
 *.tsbuildinfo
 apps/*/dist/

--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Any
 
 from parsehawk.config import (
-    DEFAULT_DATA_DIR,
     DEFAULT_VLLM_GPU_MEMORY_UTILIZATION,
     DEFAULT_VLLM_MAX_MODEL_LEN,
     DEFAULT_VLLM_MAX_NUM_SEQS,
@@ -212,7 +211,7 @@ DEFAULT_CLI_CONFIG = {
     "web.url": "http://127.0.0.1:5173",
     "runtime.url": "http://127.0.0.1:8080/v1",
     "runtime.model": _default_model(),
-    "data.dir": str(DEFAULT_DATA_DIR),
+    "data.dir": "",
     "log.level": "INFO",
 }
 CONFIG_ENV_OVERRIDES = {
@@ -481,7 +480,7 @@ def dev(args: argparse.Namespace) -> None:
         )
     settings = Settings.from_env()
     config = load_cli_config(apply_env=True)
-    data_dir = Path(args.data_dir).expanduser() if args.data_dir else settings.data_dir
+    data_dir = _resolve_data_dir(args.data_dir)
     model = args.model or settings.vllm_model
     runtime_settings = _resolve_vllm_settings(settings, model=model)
     log_level = args.log_level or config["log.level"]
@@ -686,8 +685,7 @@ def start_docker(args: argparse.Namespace) -> None:
 
     settings = Settings.from_env()
     config = load_cli_config(apply_env=True)
-    data_dir = Path(args.data_dir).expanduser() if args.data_dir else settings.data_dir
-    data_dir = data_dir.resolve()
+    data_dir = _resolve_data_dir(args.data_dir)
     model = args.model or settings.vllm_model
     runtime_settings = _resolve_vllm_settings(settings, model=model)
     log_level = args.log_level or config["log.level"]
@@ -1032,7 +1030,7 @@ def config_command(args: argparse.Namespace) -> None:
         if args.key not in DEFAULT_CLI_CONFIG:
             valid = ", ".join(sorted(DEFAULT_CLI_CONFIG))
             raise SystemExit(f"Unknown config key: {args.key}. Valid keys: {valid}")
-        config = load_cli_config(apply_env=False)
+        config = load_persisted_cli_config()
         config[args.key] = args.value
         write_cli_config(config)
         print(f"Set {args.key}={args.value}")
@@ -1513,18 +1511,8 @@ def print_check_results(checks: list[CheckResult], *, as_json: bool) -> None:
 
 
 def load_cli_config(*, apply_env: bool) -> dict[str, str]:
-    config = dict(DEFAULT_CLI_CONFIG)
-    path = cli_config_path()
-    if path.exists():
-        try:
-            payload = json.loads(path.read_text(encoding="utf-8"))
-        except json.JSONDecodeError as exc:
-            raise SystemExit(f"Invalid ParseHawk config at {path}: {exc}") from exc
-        if not isinstance(payload, dict):
-            raise SystemExit(f"Invalid ParseHawk config at {path}: expected object")
-        for key, value in payload.items():
-            if key in DEFAULT_CLI_CONFIG and isinstance(value, str):
-                config[key] = value
+    config = _default_cli_config()
+    config.update(load_persisted_cli_config())
     if apply_env:
         for key, env_name in CONFIG_ENV_OVERRIDES.items():
             env_value = os.getenv(env_name)
@@ -1533,10 +1521,31 @@ def load_cli_config(*, apply_env: bool) -> dict[str, str]:
     return config
 
 
+def load_persisted_cli_config() -> dict[str, str]:
+    path = cli_config_path()
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid ParseHawk config at {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise SystemExit(f"Invalid ParseHawk config at {path}: expected object")
+    return {
+        key: value
+        for key, value in payload.items()
+        if key in DEFAULT_CLI_CONFIG and isinstance(value, str)
+    }
+
+
 def write_cli_config(config: dict[str, str]) -> None:
     path = cli_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    persisted = {key: config[key] for key in sorted(DEFAULT_CLI_CONFIG)}
+    persisted = {
+        key: config[key]
+        for key in sorted(config)
+        if key in DEFAULT_CLI_CONFIG and isinstance(config[key], str)
+    }
     path.write_text(json.dumps(persisted, indent=2) + "\n", encoding="utf-8")
 
 
@@ -1750,8 +1759,35 @@ def _add_api_url(parser: argparse.ArgumentParser) -> None:
 
 def _resolve_data_dir(value: str | None) -> Path:
     if value:
-        return Path(value).expanduser()
-    return Settings.from_env().data_dir
+        return Path(value).expanduser().resolve()
+    env_value = os.getenv(CONFIG_ENV_OVERRIDES["data.dir"])
+    if env_value:
+        return Path(env_value).expanduser().resolve()
+    persisted = load_persisted_cli_config()
+    configured = persisted.get("data.dir")
+    if configured:
+        return Path(configured).expanduser().resolve()
+    return _default_data_dir()
+
+
+def _default_cli_config() -> dict[str, str]:
+    config = dict(DEFAULT_CLI_CONFIG)
+    config["data.dir"] = str(_default_data_dir())
+    return config
+
+
+def _default_data_dir() -> Path:
+    checkout = _dev_checkout_root()
+    if checkout is not None:
+        return checkout / "data"
+    return Path.home() / ".parsehawk" / "data"
+
+
+def _dev_checkout_root() -> Path | None:
+    repo_root = _repo_root()
+    if (repo_root / ".git").exists() and (repo_root / "pyproject.toml").is_file():
+        return repo_root
+    return None
 
 
 def _ensure_start_ports_available(args: argparse.Namespace, *, web_dir: Path) -> None:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -832,6 +832,83 @@ def test_start_uses_docker_compose_mode(tmp_path, monkeypatch: pytest.MonkeyPatc
     assert "ParseHawk started: http://127.0.0.1:8000" in output
 
 
+def test_status_uses_dev_checkout_data_dir_from_any_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    config_path = tmp_path / "config.json"
+    project_dir = tmp_path / "project"
+    other_dir = tmp_path / "elsewhere"
+    project_dir.mkdir()
+    (project_dir / ".git").mkdir()
+    (project_dir / "pyproject.toml").write_text("[project]\nname = 'parsehawk'\n", encoding="utf-8")
+    other_dir.mkdir()
+
+    monkeypatch.setenv("PARSEHAWK_CONFIG_PATH", str(config_path))
+    monkeypatch.setattr(cli, "_repo_root", lambda: project_dir)
+    monkeypatch.setattr(cli, "_print_telemetry_notice", lambda data_dir: None)
+    monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
+    monkeypatch.setattr(cli, "_wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_wait_for_url", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_compose_up", lambda **kwargs: None)
+    monkeypatch.setattr(cli, "_compose_service_running", lambda state, service: True)
+    monkeypatch.chdir(project_dir)
+
+    cli.main(["start", "--runtime", "none", "--no-web"])
+
+    data_dir = project_dir / "data"
+    assert not config_path.exists()
+    assert (data_dir / "parsehawk-state.json").is_file()
+
+    capsys.readouterr()
+    monkeypatch.chdir(other_dir)
+
+    cli.main(["status"])
+
+    output = capsys.readouterr().out
+    assert "ParseHawk is not running" not in output
+    assert "ParseHawk API: http://127.0.0.1:8000" in output
+    assert "Docker Compose:" in output
+
+
+def test_start_does_not_persist_env_data_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    config_path = tmp_path / "config.json"
+    env_data_dir = tmp_path / "env-data"
+    config_path.write_text(json.dumps({"data.dir": "data"}), encoding="utf-8")
+
+    monkeypatch.setenv("PARSEHAWK_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(env_data_dir))
+    monkeypatch.setattr(cli, "_print_telemetry_notice", lambda data_dir: None)
+    monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
+    monkeypatch.setattr(cli, "_wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_wait_for_url", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_compose_up", lambda **kwargs: None)
+
+    cli.main(["start", "--runtime", "none", "--no-web"])
+
+    assert json.loads(config_path.read_text(encoding="utf-8"))["data.dir"] == "data"
+    assert (env_data_dir / "parsehawk-state.json").is_file()
+
+
+def test_default_data_dir_uses_user_home_outside_dev_checkout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_dir = tmp_path / "installed-package"
+    home_dir = tmp_path / "home"
+    package_dir.mkdir()
+    home_dir.mkdir()
+
+    monkeypatch.setattr(cli, "_repo_root", lambda: package_dir)
+    monkeypatch.setattr(cli.Path, "home", lambda: home_dir)
+
+    assert cli._default_data_dir() == home_dir / ".parsehawk" / "data"
+
+
 def test_start_linux_vllm_uses_internal_runtime_port(
     tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
 ) -> None:
@@ -1003,7 +1080,7 @@ def test_config_set_and_list_uses_config_path(
     payload = json.loads(capsys.readouterr().out)
     assert payload["server.url"] == "http://api"
     assert payload["runtime.model"] == "numind/NuExtract3-W4A16"
-    assert json.loads(config_path.read_text(encoding="utf-8"))["server.url"] == "http://api"
+    assert json.loads(config_path.read_text(encoding="utf-8")) == {"server.url": "http://api"}
 
 
 def test_runtime_test_checks_health_and_model(monkeypatch: pytest.MonkeyPatch, capsys) -> None:


### PR DESCRIPTION
## Summary
- ignore the local example-applications workspace requested for testing
- derive the default CLI data directory from the editable checkout when present, so status/stop find repo-local state from any working directory
- fall back to ~/.parsehawk/data outside a dev checkout, and only write ~/.parsehawk/config.json when the user explicitly runs config set

Closes #29.

## Verification
- CI=true git commit hooks: ruff format, ruff check, ty check, unit tests, web typecheck, web tests
- uv run pytest tests/unit/cli/test_main.py -q --no-cov
- macOS Apple Silicon: parsehawk restart
- macOS Apple Silicon: just e2e, 17 passed
- Linux NVIDIA VM (parsehawk-vllm-test): parsehawk restart
- Linux NVIDIA VM (parsehawk-vllm-test): just e2e, 17 passed

Both macOS and Linux ParseHawk servers were stopped after verification.