### PR TITLE
Fix nullable enum schemas

### DIFF
--- a/apps/web/src/schema.test.ts
+++ b/apps/web/src/schema.test.ts
@@ -60,7 +60,7 @@ describe("schema helpers", () => {
           "x-parsehawk": { semantic: "verbatim-string" }
         },
         currency: {
-          type: "string",
+          type: ["string", "null"],
           enum: ["EUR", "USD", null],
           "x-parsehawk": { semantic: "currency" }
         },
@@ -90,7 +90,7 @@ describe("schema helpers", () => {
       type: "object",
       properties: {
         currency: {
-          type: "string",
+          type: ["string", "null"],
           enum: ["EUR", "USD", null],
           "x-parsehawk": { semantic: "currency" }
         },

--- a/apps/web/src/schemaBuilder.ts
+++ b/apps/web/src/schemaBuilder.ts
@@ -592,13 +592,14 @@ function fieldFromTemplateValue(name: string, value: unknown): SchemaField {
 
 function nullableSchema(schema: Record<string, unknown>, nullable: boolean): Record<string, unknown> {
   if (!nullable) return schema;
+  let next = schema;
+  if (isString(next.type)) {
+    next = { ...next, type: [next.type, "null"] };
+  }
   if (Array.isArray(schema.enum)) {
-    return { ...schema, enum: schema.enum.includes(null) ? schema.enum : [...schema.enum, null] };
+    return { ...next, enum: schema.enum.includes(null) ? schema.enum : [...schema.enum, null] };
   }
-  if (isString(schema.type)) {
-    return { ...schema, type: [schema.type, "null"] };
-  }
-  return schema;
+  return next;
 }
 
 function withoutNull(schema: Record<string, unknown>): Record<string, unknown> {

--- a/src/parsehawk/core/domain/schemas.py
+++ b/src/parsehawk/core/domain/schemas.py
@@ -557,13 +557,14 @@ def _nullable_schema(schema: dict[str, Any], nullable: bool) -> dict[str, Any]:
         return schema
     if ArrayAware.is_array(schema):
         return schema
-    if isinstance(schema.get("enum"), list):
-        enum = schema["enum"]
-        return {**schema, "enum": [*enum, None] if None not in enum else enum}
+    next_schema = schema
     schema_type = schema.get("type")
     if isinstance(schema_type, str):
-        return {**schema, "type": [schema_type, "null"]}
-    return schema  # pragma: no cover - defensive fallback for malformed derived schemas.
+        next_schema = {**next_schema, "type": [schema_type, "null"]}
+    if isinstance(schema.get("enum"), list):
+        enum = schema["enum"]
+        return {**next_schema, "enum": [*enum, None] if None not in enum else enum}
+    return next_schema  # pragma: no cover - defensive fallback for malformed derived schemas.
 
 
 class ArrayAware:
@@ -832,7 +833,19 @@ def _validate_authoring_json_schema_node(
 
     enum_values = schema.get("enum")
     if enum_values is not None:
+        enum_error_count = len(errors)
         _validate_authoring_enum(enum_values, path, errors)
+        if len(errors) == enum_error_count and "type" in schema:
+            enum_allows_null = any(value is None for value in enum_values)
+            type_allows_null = "null" in schema_types
+            if enum_allows_null != type_allows_null:
+                errors.append(
+                    SchemaDiagnostic(
+                        message="nullable enum fields must include null in both type and enum",
+                        code="invalid_json_schema_enum",
+                        path=f"{path}.enum",
+                    )
+                )
         if schema_type not in (None, "string"):
             errors.append(
                 SchemaDiagnostic(

--- a/src/parsehawk/server/bootstrap/seeds.py
+++ b/src/parsehawk/server/bootstrap/seeds.py
@@ -31,7 +31,7 @@ RECEIPT_SCHEMA = {
             "description": "Final amount paid after taxes, discounts, and fees.",
         },
         "currency": {
-            "type": "string",
+            "type": ["string", "null"],
             "enum": ["EUR", "USD", "GBP", None],
             "description": "Currency of the final total.",
         },

--- a/tests/fixtures/receipt/receipt_schema.json
+++ b/tests/fixtures/receipt/receipt_schema.json
@@ -22,7 +22,7 @@
       "description": "Final amount paid after taxes, discounts, and fees."
     },
     "currency": {
-      "type": "string",
+      "type": ["string", "null"],
       "enum": ["EUR", "USD", "GBP", null],
       "description": "Currency of the final total."
     }

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -844,6 +844,7 @@ def test_status_uses_dev_checkout_data_dir_from_any_directory(
     other_dir.mkdir()
 
     monkeypatch.setenv("PARSEHAWK_CONFIG_PATH", str(config_path))
+    monkeypatch.delenv("PARSEHAWK_DATA_DIR", raising=False)
     monkeypatch.setattr(cli, "_repo_root", lambda: project_dir)
     monkeypatch.setattr(cli, "_print_telemetry_notice", lambda data_dir: None)
     monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
@@ -852,6 +853,7 @@ def test_status_uses_dev_checkout_data_dir_from_any_directory(
     monkeypatch.setattr(cli, "_wait_for_api", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_wait_for_url", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_compose_up", lambda **kwargs: None)
+    monkeypatch.setattr(cli, "_compose_is_running", lambda state: True)
     monkeypatch.setattr(cli, "_compose_service_running", lambda state, service: True)
     monkeypatch.chdir(project_dir)
 

--- a/tests/unit/core/test_schemas.py
+++ b/tests/unit/core/test_schemas.py
@@ -101,7 +101,7 @@ def test_field_schema_derives_json_schema_and_nuextract_template() -> None:
                 "x-parsehawk": {"semantic": "verbatim-string"},
             },
             "status": {
-                "type": "string",
+                "type": ["string", "null"],
                 "enum": ["paid", "open", "overdue", None],
             },
             "vendor_account": {
@@ -185,7 +185,7 @@ def test_json_schema_mode_imports_nuextract_semantics_and_enums() -> None:
         "type": "object",
         "properties": {
             "buyer": {"type": ["string", "null"], "x-parsehawk": {"semantic": "verbatim-string"}},
-            "receipt_id": {"type": "string", "enum": ["1", "2", None]},
+            "receipt_id": {"type": ["string", "null"], "enum": ["1", "2", None]},
         },
         "required": ["buyer", "receipt_id"],
         "additionalProperties": False,
@@ -214,7 +214,7 @@ def test_nuextract_template_mode_derives_canonical_schema() -> None:
         "properties": {
             "store": {"type": ["string", "null"], "x-parsehawk": {"semantic": "verbatim-string"}},
             "date": {"type": ["string", "null"], "x-parsehawk": {"semantic": "date-time"}},
-            "currency": {"type": "string", "enum": ["USD", "EUR", "Other", None]},
+            "currency": {"type": ["string", "null"], "enum": ["USD", "EUR", "Other", None]},
             "tags": {
                 "type": "array",
                 "items": {"type": "string", "enum": ["urgent", "paid"]},
@@ -413,7 +413,7 @@ def test_json_schema_mode_accepts_builder_equivalent_schema_subset() -> None:
                 "type": ["string", "null"],
                 "x-parsehawk": {"semantic": "verbatim-string"},
             },
-            "status": {"type": "string", "enum": ["open", "closed", None]},
+            "status": {"type": ["string", "null"], "enum": ["open", "closed", None]},
             "tags": {"type": "array", "items": {"type": "string"}},
         },
         "required": ["vendor_account", "invoice_number", "status", "tags"],
@@ -666,6 +666,20 @@ def test_authoring_json_schema_validator_reports_malformed_subset_nodes() -> Non
         ),
         (
             {"type": "object", "properties": {"status": {"type": "string", "enum": [1]}}},
+            {"invalid_json_schema_enum"},
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"status": {"type": "string", "enum": ["open", None]}},
+            },
+            {"invalid_json_schema_enum"},
+        ),
+        (
+            {
+                "type": "object",
+                "properties": {"status": {"type": ["string", "null"], "enum": ["open"]}},
+            },
             {"invalid_json_schema_enum"},
         ),
         (
@@ -962,7 +976,8 @@ def test_json_schema_import_handles_nullable_enums_numeric_types_and_unions() ->
         {
             "type": "object",
             "properties": {
-                "nullable_enum": {"type": "string", "enum": ["a", None]},
+                "nullable_enum": {"type": ["string", "null"], "enum": ["a", None]},
+                "nullable_enum_without_type": {"enum": ["b", None]},
                 "amount": {"type": "number"},
                 "multi_type": {"type": ["string", "integer"]},
                 "branch_enum": {"anyOf": [{"enum": ["a", "b"]}, "ignored"]},
@@ -974,11 +989,13 @@ def test_json_schema_import_handles_nullable_enums_numeric_types_and_unions() ->
 
     assert imported["fields"][0]["nullable"] is True
     assert imported["fields"][0]["enum"] == ["a"]
-    assert imported["fields"][1]["nuextract_type"] == "number"
-    assert imported["fields"][2]["json_type"] == "string"
-    assert imported["fields"][3]["enum"] == ["a", "b"]
-    assert imported["fields"][4]["kind"] == "scalar"
+    assert imported["fields"][1]["nullable"] is True
+    assert imported["fields"][1]["enum"] == ["b"]
+    assert imported["fields"][2]["nuextract_type"] == "number"
+    assert imported["fields"][3]["json_type"] == "string"
+    assert imported["fields"][4]["enum"] == ["a", "b"]
     assert imported["fields"][5]["kind"] == "scalar"
+    assert imported["fields"][6]["kind"] == "scalar"
 
 
 def test_json_schema_import_handles_array_scalar_items() -> None:

--- a/tests/unit/core/test_services.py
+++ b/tests/unit/core/test_services.py
@@ -169,7 +169,7 @@ def schema() -> dict:
 def derived_schema() -> dict:
     return {
         "type": "object",
-        "properties": {"receipt_id": {"type": "string", "enum": ["2", None]}},
+        "properties": {"receipt_id": {"type": ["string", "null"], "enum": ["2", None]}},
         "required": ["receipt_id"],
         "additionalProperties": False,
     }


### PR DESCRIPTION
## Summary
- generate nullable enum JSON Schemas with both `type: ["string", "null"]` and `enum: [..., null]`
- reject authored enum schemas where nullable type and nullable enum disagree
- update bundled receipt schemas and regression tests to use the canonical nullable enum shape
- isolate the CLI status unit test from ambient `PARSEHAWK_DATA_DIR` and real Docker Compose state

Closes #42
Closes #44

## Verification
- `uv run pytest tests/unit/core/test_schemas.py tests/unit/core/test_services.py tests/unit/server/test_seeds.py -q --no-cov`
- `pnpm --dir apps/web test -- --run schema.test.ts`
- `parsehawk restart`
- `just e2e`
- `parsehawk stop`
- `just test`
