### PR TITLE
ci: cross-platform tests, shared checks, and PR issue gate

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -1,0 +1,70 @@
+name: ci-checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-checks-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  lint:
+    name: lint + typecheck (pre-commit)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      # .pre-commit-config.yaml is the single source of truth for the static
+      # checks (ruff format/check, ty, file hygiene). The heavy hooks are
+      # skipped here: unit tests run in the cross-platform ci-test matrix, and
+      # the web hooks run in the `web` job below.
+      - name: Run pre-commit (fast hooks)
+        env:
+          SKIP: unit-tests,web-typecheck,web-tests
+        run: uv run pre-commit run --all-files --show-diff-on-failure
+
+  web:
+    name: web typecheck + tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Same recipes the web-typecheck / web-tests pre-commit hooks call.
+      - name: Typecheck
+        run: just web-typecheck
+
+      - name: Test
+        run: just web-test

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,0 +1,44 @@
+name: ci-test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  test:
+    name: unit + integration (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Apple Silicon macOS (arm64)
+          - os: macos-14
+          # Linux (x86_64)
+          - os: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Sync dependencies
+        run: uv sync --frozen
+
+      # `just test` == `uv run pytest`, which runs the unit + integration
+      # suite with the 100% coverage gate. tests/e2e is excluded via the
+      # default `-m 'not e2e'` addopts because it needs the local model runtime.
+      - name: Run tests
+        run: just test

--- a/.github/workflows/enforce-issue-reference.yaml
+++ b/.github/workflows/enforce-issue-reference.yaml
@@ -1,0 +1,28 @@
+name: Enforce Issue Reference
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  check-issue-reference:
+    name: Check Issue Reference
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for Issue Reference
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const title = pr.title || '';
+
+            // Search for issue references in the format #123 or "fixes #123", "closes #123", etc.
+            const issueReferenceRegex = /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#\d+|#\d+/i;
+
+            if (!issueReferenceRegex.test(title) && !issueReferenceRegex.test(body)) {
+              core.setFailed('The pull request must reference an issue. Please add a reference in the format "#123" or "Fixes #123" or "Closes #123" to the PR title or description.');
+            } else {
+              console.log('Issue reference found. PR is compliant!');
+            }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,44 +9,46 @@ repos:
 
   - repo: local
     hooks:
+      # Entries delegate to `just` recipes so each command is defined once in
+      # the justfile (single source of truth). CI runs the same recipes.
       - id: ruff-format
         name: ruff format
-        entry: uv run ruff format --check src tests
+        entry: just format-check
         language: system
         pass_filenames: false
         always_run: true
 
       - id: ruff-check
         name: ruff check
-        entry: uv run ruff check src tests
+        entry: just lint
         language: system
         pass_filenames: false
         always_run: true
 
       - id: ty-check
         name: ty check
-        entry: uv run ty check src tests
+        entry: just typecheck
         language: system
         pass_filenames: false
         always_run: true
 
       - id: unit-tests
         name: unit tests
-        entry: uv run pytest tests/unit
+        entry: just test-unit
         language: system
         pass_filenames: false
         always_run: true
 
       - id: web-typecheck
         name: web typecheck
-        entry: pnpm --dir apps/web typecheck
+        entry: just web-typecheck
         language: system
         pass_filenames: false
         always_run: true
 
       - id: web-tests
         name: web tests
-        entry: pnpm --dir apps/web test
+        entry: just web-test
         language: system
         pass_filenames: false
         always_run: true

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ should still run the same checks; hooks are just the fast local feedback loop.
 Includes hot reload for the web UI.
 
 ```bash
-parsehawk dev   
+parsehawk dev
 ```
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -20,6 +20,9 @@ worker:
 test:
     uv run pytest
 
+test-unit:
+    uv run pytest tests/unit
+
 e2e:
     uv run pytest --no-cov -m e2e tests/e2e
 


### PR DESCRIPTION
Closes #21

## What

Adds GitHub Actions CI and removes the command duplication between the justfile, pre-commit, and CI.

### Workflows
- **`ci-test`** — runs unit + integration tests via `just test` on a matrix of **Apple Silicon macOS (`macos-14`)** and **Linux (`ubuntu-latest`)**. `tests/e2e` is excluded (it needs the local model runtime).
- **`ci-checks`** — two jobs:
  - `lint`: `pre-commit run --all-files` on Linux with the heavy hooks skipped (`SKIP=unit-tests,web-typecheck,web-tests`), so the pre-commit config is the single source of truth for ruff/ty/file-hygiene.
  - `web`: Node 22 + pnpm 10, runs `just web-typecheck` and `just web-test`.
- **`enforce-issue-reference`** — fails a PR unless the title or body references an issue. Mirrored from our other repositories.

### Single source of truth
The lint/typecheck/test commands were defined twice (justfile + inline in each pre-commit hook). Each pre-commit local hook now delegates to its `just` recipe, and CI calls the same recipes. One definition, shared by local hooks, CI, and the justfile. Added a `test-unit` recipe for the unit-tests hook.

### Housekeeping
- Stripped trailing whitespace from a README code snippet so `pre-commit run --all-files` passes on a clean tree.

## Verification
- All workflow YAML and `.pre-commit-config.yaml` parse.
- `SKIP=unit-tests,web-typecheck,web-tests pre-commit run --all-files` runs green locally: ruff-format, ruff-check, and ty-check execute through their `just` recipes; the heavy hooks skip correctly.
- Runtime/extraction behavior is unchanged, so the `parsehawk restart && just e2e` path does not apply to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)