### PR TITLE
ci: run CI on PRs only, and only for the areas that changed

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -1,14 +1,12 @@
 name: ci-checks
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 
 concurrency:
   group: ci-checks-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -41,6 +41,28 @@ jobs:
               - 'pnpm-workspace.yaml'
               - '.github/workflows/ci-checks.yaml'
 
+  hygiene:
+    name: file hygiene
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      # File-hygiene hooks apply to every file, so this job is NOT gated on
+      # changed paths — it runs on every PR, including docs-only ones. It stays
+      # light by running pre-commit through uvx (no project sync) and skips
+      # everything except the hooks from the pre-commit-hooks repo. Keep this
+      # SKIP list in sync with the hooks in .pre-commit-config.yaml.
+      - name: Run hygiene hooks
+        env:
+          SKIP: ruff-format,ruff-check,ty-check,unit-tests,web-typecheck,web-tests
+        run: uvx pre-commit run --all-files --show-diff-on-failure
+
   lint:
     name: lint + typecheck (pre-commit)
     needs: changes
@@ -62,12 +84,13 @@ jobs:
         run: uv sync --frozen
 
       # .pre-commit-config.yaml is the single source of truth for the static
-      # checks (ruff format/check, ty, file hygiene). The heavy hooks are
-      # skipped here: unit tests run in the cross-platform ci-test matrix, and
-      # the web hooks run in the `web` job below.
-      - name: Run pre-commit (fast hooks)
+      # checks. This job runs only ruff format/check and ty; the hygiene hooks
+      # run in the always-on `hygiene` job, and the unit/web hooks run in the
+      # ci-test matrix and the `web` job. Keep this SKIP list in sync with
+      # .pre-commit-config.yaml.
+      - name: Run pre-commit (ruff + ty)
         env:
-          SKIP: unit-tests,web-typecheck,web-tests
+          SKIP: check-toml,check-yaml,end-of-file-fixer,trailing-whitespace,unit-tests,web-typecheck,web-tests
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
   web:

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -9,8 +9,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    # No diff to inspect on a manual dispatch; jobs run unconditionally in
+    # that case, so path detection only applies to PRs.
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      lint: ${{ steps.filter.outputs.lint }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Detect changed areas
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            lint:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.pre-commit-config.yaml'
+              - 'justfile'
+              - '.github/workflows/ci-checks.yaml'
+            web:
+              - 'apps/web/**'
+              - 'pnpm-lock.yaml'
+              - 'pnpm-workspace.yaml'
+              - '.github/workflows/ci-checks.yaml'
+
   lint:
     name: lint + typecheck (pre-commit)
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.lint == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,6 +72,8 @@ jobs:
 
   web:
     name: web typecheck + tests
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.web == 'true') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -8,6 +8,10 @@ concurrency:
   group: ci-checks-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default; the changes job widens its own scope below.
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: detect changes

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -8,6 +8,10 @@ concurrency:
   group: ci-test-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default; the changes job widens its own scope below.
+permissions:
+  contents: read
+
 jobs:
   changes:
     name: detect changes

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -9,8 +9,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    # No diff to inspect on a manual dispatch; the test job runs
+    # unconditionally in that case, so path detection only applies to PRs.
+    if: ${{ github.event_name == 'pull_request' }}
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+    steps:
+      - name: Detect Python-affecting changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'src/**'
+              - 'tests/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - '.python-version'
+              - '.github/workflows/ci-test.yaml'
+
   test:
     name: unit + integration (${{ matrix.os }})
+    needs: changes
+    # Run when Python-affecting files changed, or on a manual dispatch (where
+    # the changes job is skipped). !cancelled() lets this evaluate even though
+    # its dependency was skipped.
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.python == 'true') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -1,14 +1,12 @@
 name: ci-test
 
 on:
-  push:
-    branches: [main]
   pull_request:
   workflow_dispatch:
 
 concurrency:
   group: ci-test-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/enforce-issue-reference.yaml
+++ b/.github/workflows/enforce-issue-reference.yaml
@@ -5,6 +5,10 @@ on:
     types: [opened, edited, synchronize, reopened]
   workflow_dispatch:
 
+# The check only reads the PR payload from the event context (no API calls).
+permissions:
+  contents: read
+
 jobs:
   check-issue-reference:
     name: Check Issue Reference


### PR DESCRIPTION
Follow-up to #21

Efficiency changes to how CI triggers, plus a dedicated always-on hygiene job.

## 1. Pull requests only
Drops the `push: branches: [main]` trigger from `ci-test` and `ci-checks`. We land PRs with **rebase-merge**, so the exact commits are already validated on the PR; re-running everything on the push to `main` just duplicated work. They now run on `pull_request` + manual `workflow_dispatch`. Concurrency guard simplified to `cancel-in-progress: true`.

## 2. Path-based filtering
Each workflow gains a lightweight `detect changes` job (`dorny/paths-filter`) and gates its expensive jobs on the result:

- **ci-test** — the macOS + Linux pytest matrix runs only when `src/**`, `tests/**`, `pyproject.toml`, `uv.lock`, `.python-version`, or the workflow file change.
- **ci-checks / lint** (ruff + ty) — runs on `src`/`tests`/`pyproject.toml`/`uv.lock`/`.pre-commit-config.yaml`/`justfile` changes.
- **ci-checks / web** — runs only when `apps/web/**`, `pnpm-lock.yaml`, or `pnpm-workspace.yaml` change.

## 3. File hygiene always runs
File-hygiene hooks (`check-toml`, `check-yaml`, `end-of-file-fixer`, `trailing-whitespace`) apply to every file, so they are split into a dedicated **`file hygiene`** job that is **not** path-gated — it runs on every PR, including docs-only ones. It stays cheap by running pre-commit through `uvx` (no project sync). Hooks are partitioned between the hygiene and lint jobs with pre-commit's `SKIP` env var (since `pre-commit run` takes at most one hook id).

Net effect: a README-only PR runs the `file hygiene` check and the near-instant `detect changes` jobs, but skips the pytest matrix, ruff/ty, and the web tests.

### Notes
- Manual `workflow_dispatch` still runs everything (no diff to inspect).
- Skipped jobs stay visible as their own check runs rather than the workflow silently not triggering — friendlier if these ever become required checks. If you make them required in branch protection, a docs-only PR would skip the gated jobs, so ping me for a small always-green gate job to avoid blocking.

## Verification
- Both workflow files parse as valid YAML.
- On this PR (which touches the workflow files) all jobs trigger; the `file hygiene` job runs and passes.