### PR TITLE
fix: seed fixed providers on api start, not only via the cli

### DIFF
--- a/src/parsehawk/server/api/fastapi/app.py
+++ b/src/parsehawk/server/api/fastapi/app.py
@@ -33,6 +33,7 @@ from parsehawk.server.api.fastapi.schemas import (
     ValidateSchemaRequest,
     ValidateSchemaResponse,
 )
+from parsehawk.server.bootstrap.seeds import seed_prebuilt_data_in_container
 from parsehawk.server.container import Container, build_container
 from parsehawk.server.runtime.inference.openai_engine import list_models
 
@@ -58,6 +59,10 @@ def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         container = build_container()
+        # Not every deployment starts through the CLI (Docker runs uvicorn
+        # directly), so the API guarantees the fixed providers and prebuilt
+        # extractors itself. Idempotent: existing operator config survives.
+        seed_prebuilt_data_in_container(container)
         app.state.container = container
         try:
             yield

--- a/tests/unit/server/test_providers_api.py
+++ b/tests/unit/server/test_providers_api.py
@@ -119,3 +119,41 @@ def test_list_provider_models_maps_provider_error_to_400(
 
     assert response.status_code == 400
     assert "unreachable" in response.json()["detail"]
+
+
+def test_app_lifespan_seeds_fixed_providers(tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A deployment that starts the app directly (Docker runs uvicorn, not the
+    CLI) must still get the fixed providers on first boot."""
+    monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARSEHAWK_DATABASE_PATH", str(tmp_path / "parsehawk.db"))
+
+    with TestClient(create_app()) as api:
+        response = api.get("/v1/providers")
+
+    assert response.status_code == 200
+    assert {provider["name"] for provider in response.json()} == {
+        "openai",
+        "azure_openai",
+        "openai_compatible_api",
+    }
+
+
+def test_app_lifespan_seeding_keeps_operator_config(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("PARSEHAWK_DATABASE_PATH", str(tmp_path / "parsehawk.db"))
+
+    with TestClient(create_app()) as api:
+        configured = api.patch(
+            "/v1/providers/azure_openai",
+            json={"base_url": "https://resource.example/openai/v1", "api_key": "sk-secret"},
+        )
+        assert configured.status_code == 200
+
+    # A restart re-runs the lifespan seeding; the operator's config survives.
+    with TestClient(create_app()) as api:
+        provider = api.get("/v1/providers/azure_openai").json()
+
+    assert provider["base_url"] == "https://resource.example/openai/v1"
+    assert provider["has_api_key"] is True


### PR DESCRIPTION
Closes #68

## Problem

The fixed providers (and the prebuilt Receipt extractor) are only seeded by the CLI start path. Docker deployments — including our own `docker/docker-compose.yml` — run `uvicorn …create_app --factory` directly, so a fresh containerized instance starts with **zero providers**, and `PATCH /v1/providers/<name>` / `parsehawk providers configure` 404 with "provider not found". Providers are fixed-set and PATCH-only by design, so there was no supported way to configure one on a Docker deployment.

## Fix

Call `seed_prebuilt_data_in_container()` in the FastAPI lifespan, so the API guarantees the fixed providers regardless of entry path.

- Idempotent and non-clobbering: only missing providers are created; operator-configured base URLs and stored API keys survive restarts (covered by a new test).
- The CLI path is unchanged — it still seeds before starting the app; the lifespan call becomes a no-op there.

## Verification

- Two new regression tests exercise the real lifespan path (the existing unit tests bypass it via dependency overrides): fresh boot exposes the three providers; a restart preserves operator config.
- `ruff format --check`, `ruff check`, `ty check`, `pytest` (206 passed, 100% core coverage gate) all green.
- Verified manually against a fresh `docker compose` stack: `GET /v1/providers` returns the three providers on first boot, and `parsehawk providers configure azure_openai` works immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)