### PR TITLE
feat: trace LM requests with a bundled, persistent Phoenix backend

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -85,7 +85,7 @@ jobs:
         uses: extractions/setup-just@v3
 
       - name: Sync dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --all-extras
 
       # .pre-commit-config.yaml is the single source of truth for the static
       # checks. This job runs only ruff format/check and ty; the hygiene hooks

--- a/.github/workflows/ci-test.yaml
+++ b/.github/workflows/ci-test.yaml
@@ -67,7 +67,7 @@ jobs:
         uses: extractions/setup-just@v3
 
       - name: Sync dependencies
-        run: uv sync --frozen
+        run: uv sync --frozen --all-extras
 
       # `just test` == `uv run pytest`, which runs the unit + integration
       # suite with the 100% coverage gate. tests/e2e is excluded via the

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ apps/*/coverage/
 playwright-report/
 test-results/
 .env
+phoenix.env

--- a/README.md
+++ b/README.md
@@ -528,16 +528,15 @@ bundled Phoenix with the standard OpenTelemetry variables:
 | Environment variable | Default | Description |
 | --- | --- | --- |
 | `OTEL_SDK_DISABLED` | `false` | Master switch for tracing. `parsehawk start -x phoenix` sets it to `true` unless you set it yourself. |
-| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://phoenix:6006` | OTLP/HTTP collector base URL (the exporter appends `/v1/traces`). |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Signal-specific override, used verbatim — set this when your collector is addressed by its full ingest URL (`…/v1/traces`). |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://phoenix:6006` | OTLP/HTTP collector **base URL** — the exporter appends `/v1/traces` itself. If the collector URL you were handed already ends in `/v1/traces`, strip that suffix. |
 | `OTEL_EXPORTER_OTLP_HEADERS` | unset | Optional headers, e.g. `authorization=Bearer <api key>` for an auth-enabled collector. Values are URL-encoded per the OTLP spec (space → `%20`). |
 | `OTEL_SERVICE_NAME` | `parsehawk-api` / `parsehawk-worker` | Service name on exported spans. |
 
 Bring-your-own collector example:
 
 ```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.com
-export OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer my-key"
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.com  # base URL, no /v1/traces
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer%20my-key"
 export OTEL_SDK_DISABLED=false
 parsehawk start -x phoenix
 ```

--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ bundled Phoenix with the standard OpenTelemetry variables:
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://phoenix:6006` | OTLP/HTTP collector **base URL** — the exporter appends `/v1/traces` itself. If the collector URL you were handed already ends in `/v1/traces`, strip that suffix. |
 | `OTEL_EXPORTER_OTLP_HEADERS` | unset | Optional headers, e.g. `authorization=Bearer <api key>` for an auth-enabled collector. Values are URL-encoded per the OTLP spec (space → `%20`). |
 | `OTEL_SERVICE_NAME` | `parsehawk-api` / `parsehawk-worker` | Service name on exported spans. |
+| `OTEL_RESOURCE_ATTRIBUTES` | `openinference.project.name=parsehawk` | Extra resource attributes. `openinference.project.name` sets the Phoenix project traces are grouped under (an OpenInference convention — other backends ignore it and group by service name). |
 
 Bring-your-own collector example:
 

--- a/README.md
+++ b/README.md
@@ -505,6 +505,66 @@ Maintainers can tag internal usage instead of dropping it:
 export PARSEHAWK_TELEMETRY_INTERNAL=1
 ```
 
+## Tracing
+
+ParseHawk traces every LM request (prompts, outputs, latency, token usage) and
+ships with a bundled, self-hosted [Arize Phoenix](https://arize.com/docs/phoenix)
+backend to view them. `parsehawk start` starts Phoenix alongside the other
+services; open the UI at `http://127.0.0.1:6006`. Traces stay on your machine:
+they are stored in Phoenix's own SQLite database under `data/phoenix/` and
+survive restarts.
+
+To start without the bundled Phoenix (this also turns tracing off):
+
+```bash
+parsehawk start -x phoenix
+```
+
+The API and worker are tracing-backend agnostic: all LM requests go through the
+OpenAI SDK, instrumented with [OpenInference](https://github.com/Arize-ai/openinference)
+and exported over standard OTLP. Point them at any OTLP collector instead of the
+bundled Phoenix with the standard OpenTelemetry variables:
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `OTEL_SDK_DISABLED` | `false` | Master switch for tracing. `parsehawk start -x phoenix` sets it to `true` unless you set it yourself. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://phoenix:6006` | OTLP/HTTP collector base URL (the exporter appends `/v1/traces`). |
+| `OTEL_EXPORTER_OTLP_HEADERS` | unset | Optional headers, e.g. `authorization=Bearer <api key>` for an auth-enabled collector. |
+| `OTEL_SERVICE_NAME` | `parsehawk-api` / `parsehawk-worker` | Service name on exported spans. |
+
+Bring-your-own collector example:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT=https://collector.example.com
+export OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer my-key"
+export OTEL_SDK_DISABLED=false
+parsehawk start -x phoenix
+```
+
+### Configuring the bundled Phoenix
+
+The Phoenix container itself is configured with its native `PHOENIX_*` variables,
+which pass through to the service (see the
+[Phoenix configuration docs](https://arize.com/docs/phoenix/self-hosting/configuration)):
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `PARSEHAWK_PHOENIX_VERSION` | `latest` | Phoenix image tag. |
+| `PARSEHAWK_PHOENIX_HOST` / `PARSEHAWK_PHOENIX_PORT` | `127.0.0.1` / `6006` | Host binding for the Phoenix UI/collector. |
+| `PHOENIX_SQL_DATABASE_URL` | SQLite under `data/phoenix/` | Trace storage. Set a `postgresql://` URL to use an external Postgres. |
+| `PHOENIX_DEFAULT_RETENTION_POLICY_DAYS` | `0` (keep forever) | Auto-delete traces older than this many days. |
+| `PHOENIX_ENABLE_AUTH` + `PHOENIX_SECRET` | `false` / unset | Enable Phoenix authentication (`PHOENIX_SECRET` must be 32+ characters). |
+
+To enable authentication end to end: set `PHOENIX_ENABLE_AUTH=true` and a
+`PHOENIX_SECRET`, restart, create an API key in the Phoenix UI (Settings), and
+hand it to the API/worker via
+`OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <api key>"`.
+
+For the long tail (OAuth2/LDAP, token expiry, admin accounts, …) drop a
+`phoenix.env` file next to `docker/docker-compose.yml` (or point
+`PARSEHAWK_PHOENIX_ENV_FILE` at one); it is loaded into the Phoenix container
+when present.
+
 ## Local Data
 
 By default ParseHawk stores local state under `data/`:
@@ -515,6 +575,7 @@ data/
   files/
   logs/
   parsehawk-state.json
+  phoenix/
   telemetry-id
 ```
 

--- a/README.md
+++ b/README.md
@@ -529,7 +529,8 @@ bundled Phoenix with the standard OpenTelemetry variables:
 | --- | --- | --- |
 | `OTEL_SDK_DISABLED` | `false` | Master switch for tracing. `parsehawk start -x phoenix` sets it to `true` unless you set it yourself. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `http://phoenix:6006` | OTLP/HTTP collector base URL (the exporter appends `/v1/traces`). |
-| `OTEL_EXPORTER_OTLP_HEADERS` | unset | Optional headers, e.g. `authorization=Bearer <api key>` for an auth-enabled collector. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | unset | Signal-specific override, used verbatim — set this when your collector is addressed by its full ingest URL (`…/v1/traces`). |
+| `OTEL_EXPORTER_OTLP_HEADERS` | unset | Optional headers, e.g. `authorization=Bearer <api key>` for an auth-enabled collector. Values are URL-encoded per the OTLP spec (space → `%20`). |
 | `OTEL_SERVICE_NAME` | `parsehawk-api` / `parsehawk-worker` | Service name on exported spans. |
 
 Bring-your-own collector example:

--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -12,6 +12,6 @@ COPY pyproject.toml uv.lock README.md LICENSE ./
 COPY docs ./docs
 COPY src ./src
 
-RUN uv sync --frozen --no-dev
+RUN uv sync --frozen --no-dev --extra tracing
 
 CMD ["uvicorn", "parsehawk.server.api.fastapi.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8000", "--no-use-colors"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -29,8 +29,11 @@ services:
       DO_NOT_TRACK: ${DO_NOT_TRACK:-0}
       OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://phoenix:6006}
-      # Pass-through (no default): only set in the container when set on the host,
-      # e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
+      # Pass-through (no default): only set in the container when set on the host.
+      # TRACES_ENDPOINT is the OTel signal-specific override, used verbatim — for
+      # collectors addressed by their full ingest URL (…/v1/traces). HEADERS carries
+      # auth, e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
       OTEL_EXPORTER_OTLP_HEADERS:
       OTEL_SERVICE_NAME: parsehawk-api
     volumes:
@@ -63,8 +66,11 @@ services:
       DO_NOT_TRACK: ${DO_NOT_TRACK:-0}
       OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-false}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://phoenix:6006}
-      # Pass-through (no default): only set in the container when set on the host,
-      # e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
+      # Pass-through (no default): only set in the container when set on the host.
+      # TRACES_ENDPOINT is the OTel signal-specific override, used verbatim — for
+      # collectors addressed by their full ingest URL (…/v1/traces). HEADERS carries
+      # auth, e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
       OTEL_EXPORTER_OTLP_HEADERS:
       OTEL_SERVICE_NAME: parsehawk-worker
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,12 @@ services:
       PARSEHAWK_TELEMETRY_DISABLED: ${PARSEHAWK_TELEMETRY_DISABLED:-0}
       PARSEHAWK_TELEMETRY_INTERNAL: ${PARSEHAWK_TELEMETRY_INTERNAL:-0}
       DO_NOT_TRACK: ${DO_NOT_TRACK:-0}
+      OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://phoenix:6006}
+      # Pass-through (no default): only set in the container when set on the host,
+      # e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
+      OTEL_EXPORTER_OTLP_HEADERS:
+      OTEL_SERVICE_NAME: parsehawk-api
     volumes:
       - ${PARSEHAWK_HOST_DATA_DIR:-../data}:/data
     ports:
@@ -55,6 +61,12 @@ services:
       PARSEHAWK_TELEMETRY_DISABLED: ${PARSEHAWK_TELEMETRY_DISABLED:-0}
       PARSEHAWK_TELEMETRY_INTERNAL: ${PARSEHAWK_TELEMETRY_INTERNAL:-0}
       DO_NOT_TRACK: ${DO_NOT_TRACK:-0}
+      OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-false}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://phoenix:6006}
+      # Pass-through (no default): only set in the container when set on the host,
+      # e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
+      OTEL_EXPORTER_OTLP_HEADERS:
+      OTEL_SERVICE_NAME: parsehawk-worker
     volumes:
       - ${PARSEHAWK_HOST_DATA_DIR:-../data}:/data
     depends_on:
@@ -68,3 +80,42 @@ services:
       - "${PARSEHAWK_WEB_HOST:-127.0.0.1}:${PARSEHAWK_WEB_PORT:-5173}:80"
     depends_on:
       - api
+
+  # Bundled tracing backend. Behind a profile so a bare `docker compose up` never
+  # starts it; `parsehawk start` activates the profile unless `-x phoenix` is set.
+  # The api/worker are intentionally not `depends_on` phoenix: tracing is
+  # best-effort (the OTLP exporter buffers and retries) and must not block the app.
+  phoenix:
+    build:
+      context: ..
+      dockerfile: services/phoenix/Dockerfile.phoenix
+      args:
+        PHOENIX_VERSION: ${PARSEHAWK_PHOENIX_VERSION:-latest}
+    profiles: ["phoenix"]
+    environment:
+      # Persistence: Phoenix's default SQLite lives in an ephemeral temp dir, so
+      # pin it to the mounted volume. Set a postgresql:// URL to use Postgres.
+      PHOENIX_WORKING_DIR: /mnt/data
+      PHOENIX_SQL_DATABASE_URL: ${PHOENIX_SQL_DATABASE_URL:-sqlite:////mnt/data/phoenix.db}
+      # Retention / metrics. Prometheus also needs a 9090 host-port mapping.
+      PHOENIX_DEFAULT_RETENTION_POLICY_DAYS: ${PHOENIX_DEFAULT_RETENTION_POLICY_DAYS:-0}
+      PHOENIX_ENABLE_PROMETHEUS: ${PHOENIX_ENABLE_PROMETHEUS:-false}
+      # Authentication: off by default. To enable, set PHOENIX_ENABLE_AUTH=true and
+      # a 32+ char PHOENIX_SECRET, create an API key in the Phoenix UI, and point
+      # the api/worker at it via OTEL_EXPORTER_OTLP_HEADERS=authorization=Bearer <key>.
+      PHOENIX_ENABLE_AUTH: ${PHOENIX_ENABLE_AUTH:-false}
+      # Pass-through (no default): Phoenix rejects a set-but-empty secret.
+      PHOENIX_SECRET:
+      PHOENIX_DISABLE_BASIC_AUTH: ${PHOENIX_DISABLE_BASIC_AUTH:-false}
+      PHOENIX_USE_SECURE_COOKIES: ${PHOENIX_USE_SECURE_COOKIES:-false}
+      PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD: ${PHOENIX_DEFAULT_ADMIN_INITIAL_PASSWORD:-admin}
+    # Optional long tail (OAuth2, LDAP, token expiry, root URL, ...) without
+    # editing this file.
+    env_file:
+      - path: ${PARSEHAWK_PHOENIX_ENV_FILE:-phoenix.env}
+        required: false
+    volumes:
+      - ${PARSEHAWK_PHOENIX_HOST_DATA_DIR:-../data/phoenix}:/mnt/data
+    ports:
+      # Port 6006 serves both the UI and OTLP/HTTP trace ingestion (/v1/traces).
+      - "${PARSEHAWK_PHOENIX_HOST:-127.0.0.1}:${PARSEHAWK_PHOENIX_PORT:-6006}:6006"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,12 +28,10 @@ services:
       PARSEHAWK_TELEMETRY_INTERNAL: ${PARSEHAWK_TELEMETRY_INTERNAL:-0}
       DO_NOT_TRACK: ${DO_NOT_TRACK:-0}
       OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-false}
+      # Base URL only — the exporter appends /v1/traces itself.
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://phoenix:6006}
-      # Pass-through (no default): only set in the container when set on the host.
-      # TRACES_ENDPOINT is the OTel signal-specific override, used verbatim — for
-      # collectors addressed by their full ingest URL (…/v1/traces). HEADERS carries
-      # auth, e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
-      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
+      # Pass-through (no default): only set in the container when set on the host,
+      # e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
       OTEL_EXPORTER_OTLP_HEADERS:
       OTEL_SERVICE_NAME: parsehawk-api
     volumes:
@@ -65,12 +63,10 @@ services:
       PARSEHAWK_TELEMETRY_INTERNAL: ${PARSEHAWK_TELEMETRY_INTERNAL:-0}
       DO_NOT_TRACK: ${DO_NOT_TRACK:-0}
       OTEL_SDK_DISABLED: ${OTEL_SDK_DISABLED:-false}
+      # Base URL only — the exporter appends /v1/traces itself.
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-http://phoenix:6006}
-      # Pass-through (no default): only set in the container when set on the host.
-      # TRACES_ENDPOINT is the OTel signal-specific override, used verbatim — for
-      # collectors addressed by their full ingest URL (…/v1/traces). HEADERS carries
-      # auth, e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
-      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT:
+      # Pass-through (no default): only set in the container when set on the host,
+      # e.g. `authorization=Bearer <api key>` for an auth-enabled collector.
       OTEL_EXPORTER_OTLP_HEADERS:
       OTEL_SERVICE_NAME: parsehawk-worker
     volumes:

--- a/justfile
+++ b/justfile
@@ -4,7 +4,7 @@ export PARSEHAWK_DATA_DIR := env_var_or_default("PARSEHAWK_DATA_DIR", "data")
 export PARSEHAWK_DATABASE_PATH := env_var_or_default("PARSEHAWK_DATABASE_PATH", "data/parsehawk.db")
 
 setup:
-    uv sync
+    uv sync --all-extras
     pnpm install
     uv run pre-commit install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,15 @@ dependencies = [
     "uvicorn[standard]>=0.32.0",
 ]
 
+[project.optional-dependencies]
+# Backend-agnostic OTLP tracing for LM requests (bundled Phoenix is one target).
+# Kept out of the default install; the Docker image installs it via --extra tracing.
+tracing = [
+    "opentelemetry-sdk>=1.27.0",
+    "opentelemetry-exporter-otlp-proto-http>=1.27.0",
+    "openinference-instrumentation-openai>=0.1.0",
+]
+
 [dependency-groups]
 dev = [
     "httpx>=0.27.0",

--- a/services/phoenix/Dockerfile.phoenix
+++ b/services/phoenix/Dockerfile.phoenix
@@ -1,0 +1,7 @@
+# Bundled Arize Phoenix tracing backend.
+#
+# A thin wrapper over the upstream image so the version pin and any future
+# customization live in-repo. Persistence, ports, retention, and authentication
+# are configured through environment variables in docker/docker-compose.yml.
+ARG PHOENIX_VERSION=latest
+FROM arizephoenix/phoenix:${PHOENIX_VERSION}

--- a/services/phoenix/Dockerfile.phoenix
+++ b/services/phoenix/Dockerfile.phoenix
@@ -3,5 +3,5 @@
 # A thin wrapper over the upstream image so the version pin and any future
 # customization live in-repo. Persistence, ports, retention, and authentication
 # are configured through environment variables in docker/docker-compose.yml.
-ARG PHOENIX_VERSION=latest
+ARG PHOENIX_VERSION=17.20.0
 FROM arizephoenix/phoenix:${PHOENIX_VERSION}

--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -254,6 +254,8 @@ class ParseHawkState:
     mode: str = "local"
     compose_project: str | None = None
     compose_files: list[str] | None = None
+    compose_profiles: list[str] | None = None
+    phoenix_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -788,7 +790,7 @@ def start_docker(args: argparse.Namespace) -> None:
 
     web_dir = _repo_root() / "apps" / "web"
     _progress("Checking ports")
-    _ensure_start_ports_available(args, web_dir=web_dir)
+    _ensure_start_ports_available(args, web_dir=web_dir, include_phoenix=_phoenix_enabled(args))
     _progress("Checking Docker")
     _ensure_docker_available()
     _progress("Checking platform dependencies")
@@ -799,6 +801,12 @@ def start_docker(args: argparse.Namespace) -> None:
     logs_dir = data_dir / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True)
     database_path = data_dir / "parsehawk.db"
+    phoenix_enabled = _phoenix_enabled(args)
+    if phoenix_enabled:
+        # Phoenix persists its own SQLite database (and exports) here, kept
+        # separate from parsehawk.db: Phoenix owns its schema migrations and
+        # SQLite is single-writer, so sharing one file would entangle the two.
+        (data_dir / "phoenix").mkdir(parents=True, exist_ok=True)
     _print_telemetry_notice(data_dir)
     _apply_migrations_at_start(args, database_path)
 
@@ -879,6 +887,7 @@ def start_docker(args: argparse.Namespace) -> None:
         log_level=log_level,
         model=model,
         runtime_url=container_runtime_url,
+        phoenix_enabled=phoenix_enabled,
     )
     services = ["api", "worker"]
     web_enabled = not args.no_web and (web_dir / "package.json").exists()
@@ -886,6 +895,10 @@ def start_docker(args: argparse.Namespace) -> None:
         services.append("web")
     if args.runtime == "vllm" and _is_linux_x86_64():
         services.insert(0, "runtime")
+    compose_profiles: list[str] = []
+    if phoenix_enabled:
+        services.append("phoenix")
+        compose_profiles.append("phoenix")
 
     state = ParseHawkState(
         data_dir=str(data_dir),
@@ -896,6 +909,8 @@ def start_docker(args: argparse.Namespace) -> None:
         mode="docker",
         compose_project=compose_project,
         compose_files=[str(path) for path in compose_files],
+        compose_profiles=compose_profiles or None,
+        phoenix_url=_phoenix_url() if phoenix_enabled else None,
     )
     _write_state(state_path, state)
     try:
@@ -914,6 +929,7 @@ def start_docker(args: argparse.Namespace) -> None:
             project_name=compose_project,
             env=compose_env,
             services=services,
+            profiles=compose_profiles or None,
         )
         if runtime_url and runtime_process is None:
             _progress(f"Waiting for Model Runtime: {runtime_url}")
@@ -929,9 +945,17 @@ def start_docker(args: argparse.Namespace) -> None:
         if state.web_url:
             _progress(f"Waiting for ParseHawk Web UI: {state.web_url}")
             _wait_for_url(state.web_url, name="ParseHawk Web UI")
+        if state.phoenix_url:
+            _progress(f"Waiting for Phoenix Tracing: {state.phoenix_url}")
+            _wait_for_phoenix(state.phoenix_url)
         _ensure_managed_processes_alive(processes)
     except BaseException:
-        _compose_down(compose_files=compose_files, project_name=compose_project, env=compose_env)
+        _compose_down(
+            compose_files=compose_files,
+            project_name=compose_project,
+            env=compose_env,
+            profiles=compose_profiles or None,
+        )
         _stop_processes(processes)
         state_path.unlink(missing_ok=True)
         raise
@@ -941,6 +965,8 @@ def start_docker(args: argparse.Namespace) -> None:
         print(f"ParseHawk Web UI: {state.web_url}")
     if runtime_url:
         print(f"Model Runtime: {runtime_url}")
+    if state.phoenix_url:
+        print(f"Phoenix Tracing: {state.phoenix_url}")
     print(f"Logs: {logs_dir}")
 
 
@@ -979,10 +1005,15 @@ def _print_status(state: ParseHawkState) -> None:
         print(f"Model Runtime: {state.runtime_url}")
     if state.web_url:
         print(f"ParseHawk Web UI: {state.web_url}")
+    if state.phoenix_url:
+        print(f"Phoenix Tracing: {state.phoenix_url}")
     if state.mode == "docker" and state.compose_project and state.compose_files:
         running = "running" if _compose_is_running(state) else "stopped"
         print(f"Docker Compose: {running} project={state.compose_project}")
-        for service in ("api", "worker", "web"):
+        services = (
+            ("api", "worker", "web", "phoenix") if state.phoenix_url else ("api", "worker", "web")
+        )
+        for service in services:
             status_text = "running" if _compose_service_running(state, service) else "stopped"
             print(f"{_service_display_name(service)}: {status_text}")
     for process in state.processes:
@@ -1276,6 +1307,17 @@ def _should_skip_migrations(args: argparse.Namespace) -> bool:
     return migrations_disabled()
 
 
+def _phoenix_enabled(args: argparse.Namespace) -> bool:
+    return "phoenix" not in (getattr(args, "exclude", None) or [])
+
+
+def _phoenix_url() -> str:
+    """Host-side Phoenix UI/collector URL, honoring the compose port overrides."""
+    host = os.getenv("PARSEHAWK_PHOENIX_HOST", "127.0.0.1")
+    port = os.getenv("PARSEHAWK_PHOENIX_PORT", "6006")
+    return f"http://{host}:{port}"
+
+
 def _apply_migrations_at_start(args: argparse.Namespace, database_path: Path) -> None:
     """Apply pending migrations before serving, honoring the opt-out.
 
@@ -1490,6 +1532,7 @@ def _compose_env(
     log_level: str,
     model: str,
     runtime_url: str | None,
+    phoenix_enabled: bool,
 ) -> dict[str, str]:
     env = os.environ.copy()
     env.update(
@@ -1515,13 +1558,28 @@ def _compose_env(
         }
     )
     env["PARSEHAWK_DATABASE_PATH"] = str(database_path).replace(str(data_dir), "/data", 1)
+    if phoenix_enabled:
+        # Traces persist next to the app data; the OTLP endpoint default lives in
+        # the compose file and an operator's OTEL_* env (copied above) still wins.
+        env["PARSEHAWK_PHOENIX_HOST_DATA_DIR"] = str(data_dir / "phoenix")
+    else:
+        # `-x phoenix` turns tracing off unless the operator explicitly pointed
+        # the exporter somewhere themselves (bring-your-own collector).
+        env.setdefault("OTEL_SDK_DISABLED", "true")
     return env
 
 
-def _compose_command(compose_files: list[Path], project_name: str, *args: str) -> list[str]:
+def _compose_command(
+    compose_files: list[Path],
+    project_name: str,
+    *args: str,
+    profiles: list[str] | None = None,
+) -> list[str]:
     command = ["docker", "compose", "--project-name", project_name]
     for compose_file in compose_files:
         command.extend(["--file", str(compose_file)])
+    for profile in profiles or []:
+        command.extend(["--profile", profile])
     command.extend(args)
     return command
 
@@ -1532,10 +1590,19 @@ def _compose_up(
     project_name: str,
     env: dict[str, str],
     services: list[str],
+    profiles: list[str] | None = None,
 ) -> None:
     try:
         subprocess.run(
-            _compose_command(compose_files, project_name, "up", "--detach", "--build", *services),
+            _compose_command(
+                compose_files,
+                project_name,
+                "up",
+                "--detach",
+                "--build",
+                *services,
+                profiles=profiles,
+            ),
             cwd=_repo_root(),
             env=env,
             check=True,
@@ -1550,9 +1617,17 @@ def _compose_up(
         ) from exc
 
 
-def _compose_down(*, compose_files: list[Path], project_name: str, env: dict[str, str]) -> None:
+def _compose_down(
+    *,
+    compose_files: list[Path],
+    project_name: str,
+    env: dict[str, str],
+    profiles: list[str] | None = None,
+) -> None:
     subprocess.run(
-        _compose_command(compose_files, project_name, "down", "--remove-orphans"),
+        _compose_command(
+            compose_files, project_name, "down", "--remove-orphans", profiles=profiles
+        ),
         cwd=_repo_root(),
         env=env,
         stdout=subprocess.DEVNULL,
@@ -1582,6 +1657,7 @@ def _compose_running_services(state: ParseHawkState) -> set[str]:
                 "running",
                 "--format",
                 "json",
+                profiles=state.compose_profiles,
             ),
             cwd=_repo_root(),
             stdout=subprocess.PIPE,
@@ -1629,7 +1705,7 @@ def _compose_service_name(item: dict[str, Any]) -> str | None:
     name = item.get("Name")
     if not isinstance(name, str) or not name:
         return None
-    for service_name in ("api", "worker", "web", "runtime"):
+    for service_name in ("api", "worker", "web", "runtime", "phoenix"):
         if (
             f"-{service_name}-" in name
             or f"_{service_name}_" in name
@@ -1646,6 +1722,7 @@ def _service_display_name(name: str) -> str:
         "worker": "ParseHawk Worker",
         "web": "ParseHawk Web UI",
         "runtime": "Model Runtime",
+        "phoenix": "Phoenix Tracing",
     }.get(name, name)
 
 
@@ -1660,6 +1737,7 @@ def _stop_state(state: ParseHawkState) -> None:
                 "PARSEHAWK_HOST_DATA_DIR": str(data_dir),
                 "PARSEHAWK_DATA_DIR": "/data",
             },
+            profiles=state.compose_profiles,
         )
     _stop_processes(state.processes)
 
@@ -1966,13 +2044,15 @@ def _add_start_options(
         "-x",
         "--exclude",
         action="append",
-        choices=["migrate", "runtime"],
+        choices=["migrate", "runtime", "phoenix"],
         default=None,
         metavar="COMPONENT",
         help=(
             "Skip a start-time component. Repeatable. Supports: migrate (database "
-            "migrations) and runtime (the bundled model runtime; use this to run "
-            "against a configured cloud/remote provider instead)."
+            "migrations), runtime (the bundled model runtime; use this to run "
+            "against a configured cloud/remote provider instead), and phoenix (the "
+            "bundled Phoenix tracing backend; also turns off LM request tracing "
+            "unless OTEL_SDK_DISABLED is set explicitly)."
         ),
     )
     parser.add_argument(
@@ -2032,12 +2112,17 @@ def _dev_checkout_root() -> Path | None:
     return None
 
 
-def _ensure_start_ports_available(args: argparse.Namespace, *, web_dir: Path) -> None:
+def _ensure_start_ports_available(
+    args: argparse.Namespace, *, web_dir: Path, include_phoenix: bool = False
+) -> None:
     checks = [("API", args.host, args.port)]
     if args.runtime == "vllm":
         checks.append(("Model Runtime", args.runtime_host, args.runtime_port))
     if not args.no_web and (web_dir / "package.json").exists():
         checks.append(("Web UI", args.web_host, args.web_port))
+    if include_phoenix:
+        phoenix = urllib.parse.urlsplit(_phoenix_url())
+        checks.append(("Phoenix Tracing", phoenix.hostname or "127.0.0.1", phoenix.port or 6006))
 
     for name, host, port in checks:
         if _tcp_port_open(host, port):
@@ -2100,6 +2185,22 @@ def _wait_for_url(url: str, name: str = "URL", timeout_seconds: int = 30) -> Non
     raise SystemExit(f"{name} did not become ready at {url}")
 
 
+def _wait_for_phoenix(phoenix_url: str) -> None:
+    """Wait for the tracing backend without failing the start.
+
+    Tracing is best-effort: the OTLP exporter buffers and retries, so a slow or
+    broken Phoenix must not take the app stack down with it.
+    """
+    try:
+        _wait_for_url(phoenix_url, name="Phoenix Tracing", timeout_seconds=60)
+    except SystemExit:
+        _progress(
+            f"Phoenix Tracing did not become ready at {phoenix_url}; continuing without "
+            "it. Inspect the phoenix container logs, or start with `-x phoenix` to "
+            "disable tracing."
+        )
+
+
 def _wait_for_runtime(health_url: str, process: ManagedProcess, *, timeout_seconds: int) -> None:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
@@ -2150,6 +2251,8 @@ def _load_state(path: Path) -> ParseHawkState:
         mode=payload.get("mode", "local"),
         compose_project=payload.get("compose_project"),
         compose_files=payload.get("compose_files"),
+        compose_profiles=payload.get("compose_profiles"),
+        phoenix_url=payload.get("phoenix_url"),
     )
 
 

--- a/src/parsehawk/server/api/fastapi/app.py
+++ b/src/parsehawk/server/api/fastapi/app.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, FastAPI, File, Query, Request, UploadFil
 from fastapi.responses import FileResponse as FastAPIFileResponse
 from fastapi.responses import JSONResponse
 
-from parsehawk import telemetry
+from parsehawk import telemetry, tracing
 from parsehawk.core.domain.errors import NotFoundError, ProviderRequestError, ValidationFailure
 from parsehawk.core.domain.models import ProviderName
 from parsehawk.core.domain.schemas import (
@@ -59,6 +59,7 @@ health_router = APIRouter(tags=["health"])
 def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        tracing.configure_tracing(service_name="parsehawk-api")
         container = build_container()
         # Not every deployment starts through the CLI (Docker runs uvicorn
         # directly), so the API guarantees the fixed providers and prebuilt

--- a/src/parsehawk/server/worker/main.py
+++ b/src/parsehawk/server/worker/main.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 import time
 
+from parsehawk import tracing
 from parsehawk.logging import configure_logging
 from parsehawk.server.container import build_container
 
@@ -38,6 +39,7 @@ def main() -> None:
     parser.add_argument("--once", action="store_true")
     parser.add_argument("--poll-seconds", type=float, default=1.0)
     args = parser.parse_args()
+    tracing.configure_tracing(service_name="parsehawk-worker")
     if args.once:
         run_once()
     else:

--- a/src/parsehawk/tracing.py
+++ b/src/parsehawk/tracing.py
@@ -95,7 +95,9 @@ def _register(service_name: str) -> None:
     # Every provider goes through the OpenAI SDK, so instrumenting it covers all
     # LM requests (chat completions and model listing alike).
     OpenAIInstrumentor().instrument(tracer_provider=provider)
-    logger.info(
-        "Tracing LM requests via OTLP: %s",
-        os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
+    # Mirror the exporter's endpoint resolution: the signal-specific variable is a
+    # full ingest URL used verbatim; the generic one gets /v1/traces appended.
+    endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or os.getenv(
+        "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"
     )
+    logger.info("Tracing LM requests via OTLP: %s", endpoint)

--- a/src/parsehawk/tracing.py
+++ b/src/parsehawk/tracing.py
@@ -1,0 +1,101 @@
+"""Backend-agnostic OTLP tracing for LM requests.
+
+ParseHawk drives every model provider through the OpenAI SDK
+(:mod:`parsehawk.server.runtime.inference.openai_engine`), so LM observability is
+implemented as OpenInference auto-instrumentation of that client exporting OTLP
+spans. The app knows nothing about any specific tracing backend: the bundled
+Arize Phoenix service is simply the default OTLP target that `parsehawk start`
+wires up, and any other collector works by overriding the standard
+OpenTelemetry env vars:
+
+- ``OTEL_SDK_DISABLED`` — master switch (``parsehawk start -x phoenix`` sets it).
+- ``OTEL_EXPORTER_OTLP_ENDPOINT`` — OTLP/HTTP collector base URL.
+- ``OTEL_EXPORTER_OTLP_HEADERS`` — optional auth, e.g.
+  ``authorization=Bearer <api key>`` for an auth-enabled Phoenix.
+- ``OTEL_SERVICE_NAME`` / ``OTEL_RESOURCE_ATTRIBUTES`` — resource overrides.
+
+These are OTel-ecosystem standard names, so (like ``DO_NOT_TRACK`` in
+:mod:`parsehawk.telemetry`) they are read straight from the environment instead
+of :class:`~parsehawk.config.Settings`, which prefixes everything with
+``PARSEHAWK_``.
+
+Like telemetry, tracing must never slow down or break a Run: the OTel/
+OpenInference dependencies are an optional extra (``parsehawk[tracing]``), and
+every failure here — missing packages, bad config, unreachable collector —
+degrades to a no-op instead of an error.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# Groups ParseHawk's spans under one Phoenix project; override via the standard
+# OTEL_RESOURCE_ATTRIBUTES (e.g. "openinference.project.name=my-project").
+_PROJECT_NAME_ATTRIBUTE = "openinference.project.name"
+_DEFAULT_PROJECT_NAME = "parsehawk"
+
+_configured = False
+
+
+def _is_truthy(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in _TRUTHY
+
+
+def tracing_disabled() -> bool:
+    """Return whether tracing is switched off via the OTel-standard env var."""
+    return _is_truthy(os.getenv("OTEL_SDK_DISABLED"))
+
+
+def configure_tracing(*, service_name: str) -> None:
+    """Set up OTLP span export and LM auto-instrumentation for this process.
+
+    Called once at process startup (API lifespan, worker main). Idempotent, and
+    a no-op when tracing is disabled or the optional tracing dependencies are
+    not installed.
+    """
+    global _configured
+    if _configured:
+        return
+    _configured = True
+    if tracing_disabled():
+        return
+    try:
+        _register(service_name)
+    except Exception:  # pragma: no cover - defensive; tracing must never break a Run
+        logger.debug("tracing: failed to configure OTLP tracing", exc_info=True)
+
+
+def _register(service_name: str) -> None:
+    from openinference.instrumentation.openai import OpenAIInstrumentor
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    # Resource.create() lets explicitly passed attributes win over the standard
+    # env detectors, so only fill the gaps: the env vars must stay authoritative.
+    attributes: dict[str, str] = {}
+    if not os.getenv("OTEL_SERVICE_NAME"):
+        attributes["service.name"] = service_name
+    if _PROJECT_NAME_ATTRIBUTE not in os.getenv("OTEL_RESOURCE_ATTRIBUTES", ""):
+        attributes[_PROJECT_NAME_ATTRIBUTE] = _DEFAULT_PROJECT_NAME
+
+    # The exporter reads OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_HEADERS
+    # itself; batching keeps span export off the request path.
+    provider = TracerProvider(resource=Resource.create(attributes))
+    provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(provider)
+
+    # Every provider goes through the OpenAI SDK, so instrumenting it covers all
+    # LM requests (chat completions and model listing alike).
+    OpenAIInstrumentor().instrument(tracer_provider=provider)
+    logger.info(
+        "Tracing LM requests via OTLP: %s",
+        os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
+    )

--- a/src/parsehawk/tracing.py
+++ b/src/parsehawk/tracing.py
@@ -95,9 +95,7 @@ def _register(service_name: str) -> None:
     # Every provider goes through the OpenAI SDK, so instrumenting it covers all
     # LM requests (chat completions and model listing alike).
     OpenAIInstrumentor().instrument(tracer_provider=provider)
-    # Mirror the exporter's endpoint resolution: the signal-specific variable is a
-    # full ingest URL used verbatim; the generic one gets /v1/traces appended.
-    endpoint = os.getenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT") or os.getenv(
-        "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"
+    logger.info(
+        "Tracing LM requests via OTLP: %s",
+        os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318"),
     )
-    logger.info("Tracing LM requests via OTLP: %s", endpoint)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,11 +58,12 @@ def _first_non_empty_line(text: str) -> str | None:
 
 @pytest.fixture(autouse=True)
 def _disable_telemetry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep the suite hermetic: no usage analytics are sent during tests.
+    """Keep the suite hermetic: no usage analytics or trace export during tests.
 
-    Telemetry-specific tests opt back in by clearing these vars themselves.
+    Telemetry/tracing-specific tests opt back in by clearing these vars themselves.
     """
     monkeypatch.setenv("PARSEHAWK_TELEMETRY_DISABLED", "1")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
 
 
 class _StubEngineFactory:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -887,7 +887,7 @@ def test_start_uses_docker_compose_mode(tmp_path, monkeypatch: pytest.MonkeyPatc
 
     cli.main(["start", "-x", "runtime"])
 
-    assert compose_ups[0]["services"] == ["api", "worker", "web"]
+    assert compose_ups[0]["services"] == ["api", "worker", "web", "phoenix"]
     assert compose_ups[0]["env"]["PARSEHAWK_INFERENCE_ENGINE"] == "none"
     assert compose_ups[0]["env"]["PARSEHAWK_HOST_DATA_DIR"] == str(data_dir.resolve())
     state = cli._load_state(data_dir / "parsehawk-state.json")
@@ -897,7 +897,7 @@ def test_start_uses_docker_compose_mode(tmp_path, monkeypatch: pytest.MonkeyPatc
     output = capsys.readouterr().out
     assert "==> Starting ParseHawk in Docker mode" in output
     assert "==> Checking Docker" in output
-    assert "==> Building and starting Docker services: api, worker, web" in output
+    assert "==> Building and starting Docker services: api, worker, web, phoenix" in output
     assert "ParseHawk started: http://127.0.0.1:8000" in output
 
 
@@ -940,7 +940,7 @@ def test_start_macos_docker_vllm_seeds_container_runtime_provider_url(
     cli.main(["start", "--runtime-port", "18080", "--no-web"])
 
     assert [process["name"] for process in spawned] == ["runtime"]
-    assert compose_ups[0]["services"] == ["api", "worker"]
+    assert compose_ups[0]["services"] == ["api", "worker", "phoenix"]
     assert compose_ups[0]["env"]["PARSEHAWK_VLLM_BASE_URL"] == (
         "http://host.docker.internal:18080/v1"
     )
@@ -1051,7 +1051,7 @@ def test_start_linux_vllm_uses_internal_runtime_port(
     monkeypatch.setattr(cli, "_default_runtime", lambda: "vllm")
     cli.main(["start", "--runtime-port", "18080", "--no-web"])
 
-    assert compose_ups[0]["services"] == ["runtime", "api", "worker"]
+    assert compose_ups[0]["services"] == ["runtime", "api", "worker", "phoenix"]
     assert any(path.name == "docker-compose.linux.yml" for path in compose_ups[0]["compose_files"])
     assert compose_ups[0]["env"]["PARSEHAWK_RUNTIME_PORT"] == "18080"
     assert compose_ups[0]["env"]["PARSEHAWK_INFERENCE_ENGINE"] == "vllm"
@@ -1060,7 +1060,8 @@ def test_start_linux_vllm_uses_internal_runtime_port(
     assert compose_ups[0]["env"]["PARSEHAWK_VLLM_MAX_MODEL_LEN"] == "16384"
     assert compose_ups[0]["env"]["PARSEHAWK_VLLM_MAX_NUM_SEQS"] == "4"
     assert compose_ups[0]["env"]["PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION"] == "0.85"
-    assert runtime_health_urls == ["http://127.0.0.1:18080/health"]
+    # Runtime health first, then the Phoenix Tracing readiness probe.
+    assert runtime_health_urls == ["http://127.0.0.1:18080/health", "http://127.0.0.1:6006"]
     state = cli._load_state(data_dir / "parsehawk-state.json")
     assert state.runtime_url == "http://127.0.0.1:18080/v1"
     output = capsys.readouterr().out
@@ -1155,6 +1156,7 @@ def test_restart_stops_tracked_processes_then_starts(
     monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
     monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
     monkeypatch.setattr(cli, "_wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_wait_for_phoenix", lambda *args, **kwargs: None)
     monkeypatch.setattr(
         cli,
         "_compose_down",
@@ -1179,7 +1181,7 @@ def test_restart_stops_tracked_processes_then_starts(
 
     state = cli._load_state(tmp_path / "parsehawk-state.json")
     assert compose_downs == ["parsehawk_test"]
-    assert compose_ups == [["api", "worker"]]
+    assert compose_ups == [["api", "worker", "phoenix"]]
     assert state.mode == "docker"
     assert state.processes == []
     assert "ParseHawk stopped" in capsys.readouterr().out
@@ -1535,12 +1537,113 @@ def test_start_exclude_migrate_propagates_skip_to_containers(
     monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
     monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
     monkeypatch.setattr(cli, "_wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_wait_for_phoenix", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_compose_up", lambda **kwargs: compose_ups.append(kwargs))
 
     cli.main(["start", "-x", "runtime", "--no-web", "-x", "migrate"])
 
     assert compose_ups[0]["env"]["PARSEHAWK_SKIP_MIGRATIONS"] == "1"
     assert "Skipping database migrations" in capsys.readouterr().out
+
+
+def _mock_docker_start_infra(
+    monkeypatch: pytest.MonkeyPatch, compose_ups: list[dict[str, Any]]
+) -> None:
+    monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
+    monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
+    monkeypatch.setattr(cli, "_wait_for_api", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_wait_for_phoenix", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cli, "_compose_up", lambda **kwargs: compose_ups.append(kwargs))
+
+
+def test_start_includes_phoenix_by_default(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    data_dir = tmp_path / "data"
+    compose_ups: list[dict[str, Any]] = []
+    monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARSEHAWK_SKIP_MIGRATIONS", "0")
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    _mock_docker_start_infra(monkeypatch, compose_ups)
+
+    cli.main(["start", "-x", "runtime", "--no-web"])
+
+    up = compose_ups[0]
+    assert "phoenix" in up["services"]
+    assert up["profiles"] == ["phoenix"]
+    # Traces persist under the data directory; tracing stays enabled.
+    assert up["env"]["PARSEHAWK_PHOENIX_HOST_DATA_DIR"] == str(data_dir / "phoenix")
+    assert "OTEL_SDK_DISABLED" not in up["env"]
+    assert (data_dir / "phoenix").is_dir()
+    state = json.loads((data_dir / "parsehawk-state.json").read_text(encoding="utf-8"))
+    assert state["compose_profiles"] == ["phoenix"]
+    assert state["phoenix_url"] == "http://127.0.0.1:6006"
+    assert "Phoenix Tracing: http://127.0.0.1:6006" in capsys.readouterr().out
+
+
+def test_start_exclude_phoenix_omits_service_and_disables_tracing(
+    tmp_path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    data_dir = tmp_path / "data"
+    compose_ups: list[dict[str, Any]] = []
+    monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARSEHAWK_SKIP_MIGRATIONS", "0")
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    _mock_docker_start_infra(monkeypatch, compose_ups)
+
+    cli.main(["start", "-x", "runtime", "-x", "phoenix", "--no-web"])
+
+    up = compose_ups[0]
+    assert "phoenix" not in up["services"]
+    assert up["profiles"] is None
+    assert up["env"]["OTEL_SDK_DISABLED"] == "true"
+    assert not (data_dir / "phoenix").exists()
+    state = json.loads((data_dir / "parsehawk-state.json").read_text(encoding="utf-8"))
+    assert state["compose_profiles"] is None
+    assert state["phoenix_url"] is None
+    assert "Phoenix Tracing" not in capsys.readouterr().out
+
+
+def test_start_exclude_phoenix_keeps_explicit_otel_override(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`-x phoenix` with a bring-your-own collector keeps tracing on."""
+    data_dir = tmp_path / "data"
+    compose_ups: list[dict[str, Any]] = []
+    monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("PARSEHAWK_SKIP_MIGRATIONS", "0")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+    _mock_docker_start_infra(monkeypatch, compose_ups)
+
+    cli.main(["start", "-x", "runtime", "-x", "phoenix", "--no-web"])
+
+    assert compose_ups[0]["env"]["OTEL_SDK_DISABLED"] == "false"
+    assert compose_ups[0]["env"]["OTEL_EXPORTER_OTLP_ENDPOINT"] == "http://collector:4318"
+
+
+def test_compose_command_places_profiles_before_subcommand() -> None:
+    command = cli._compose_command(
+        [Path("docker-compose.yml")],
+        "parsehawk_test",
+        "up",
+        "--detach",
+        profiles=["phoenix"],
+    )
+
+    assert command == [
+        "docker",
+        "compose",
+        "--project-name",
+        "parsehawk_test",
+        "--file",
+        "docker-compose.yml",
+        "--profile",
+        "phoenix",
+        "up",
+        "--detach",
+    ]
 
 
 def test_providers_list_get_and_models_hit_endpoints(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import pytest
+
+from parsehawk import tracing
+
+
+@pytest.fixture(autouse=True)
+def reset_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure each test starts unconfigured and opted back in (conftest opts out)."""
+    monkeypatch.setattr(tracing, "_configured", False)
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+
+
+def test_enabled_by_default() -> None:
+    assert tracing.tracing_disabled() is False
+
+
+@pytest.mark.parametrize("value", ["1", "true", "YES", "on"])
+def test_disabled_by_env_var(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", value)
+    assert tracing.tracing_disabled() is True
+
+
+@pytest.mark.parametrize("value", ["0", "false", ""])
+def test_falsey_value_keeps_tracing_enabled(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", value)
+    assert tracing.tracing_disabled() is False
+
+
+def test_configure_tracing_registers_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    registered: list[str] = []
+    monkeypatch.setattr(tracing, "_register", registered.append)
+
+    tracing.configure_tracing(service_name="parsehawk-api")
+    tracing.configure_tracing(service_name="parsehawk-api")
+
+    assert registered == ["parsehawk-api"]
+
+
+def test_configure_tracing_is_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    registered: list[str] = []
+    monkeypatch.setattr(tracing, "_register", registered.append)
+
+    tracing.configure_tracing(service_name="parsehawk-api")
+
+    assert registered == []
+
+
+def test_configure_tracing_swallows_missing_dependencies(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(service_name: str) -> None:
+        raise ImportError("No module named 'opentelemetry'")
+
+    monkeypatch.setattr(tracing, "_register", _boom)
+
+    # Must not raise — the tracing extra is optional and tracing can never
+    # break a Run.
+    tracing.configure_tracing(service_name="parsehawk-worker")
+
+
+def test_configure_tracing_swallows_registration_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(service_name: str) -> None:
+        raise RuntimeError("collector misconfigured")
+
+    monkeypatch.setattr(tracing, "_register", _boom)
+
+    tracing.configure_tracing(service_name="parsehawk-api")

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631 },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +495,144 @@ wheels = [
 ]
 
 [[package]]
+name = "openinference-instrumentation"
+version = "0.1.54"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-sdk" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/cc/62c1175ee7edc2cbdf95b5b73e0b0f305e759d407bf1bc353ff30a763365/openinference_instrumentation-0.1.54.tar.gz", hash = "sha256:9af9817bb38816ed32856fb4cd813c1a5d9f530ab589c3473b37e06cf406ab28", size = 33938 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/e3/c7aa7bb4845e0cfdf477ff87f9a3ec0cd2aa55a34a9f31be84d724cabbb7/openinference_instrumentation-0.1.54-py3-none-any.whl", hash = "sha256:8bc991865c90c804ac9983ef93aa6081a7a2397dd113d3d38b5465cca17892bb", size = 41197 },
+]
+
+[[package]]
+name = "openinference-instrumentation-openai"
+version = "0.1.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "openinference-instrumentation" },
+    { name = "openinference-semantic-conventions" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/90/c81c7426cb9dca075cef1b5fe16f58c68604b7518f7aaa14d837ec80fde3/openinference_instrumentation_openai-0.1.52.tar.gz", hash = "sha256:5a3dceb742209463e33ab2a4aa82f56bedfa20c25c738de28248509931044ea1", size = 23087 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/ff/10d75f37dd006072db725d36a30b343386d6404526eeda877bbe37157abe/openinference_instrumentation_openai-0.1.52-py3-none-any.whl", hash = "sha256:aa96d41cb755e0d9b3d5a09331d991b7424c017c107d0bf196b03d3e5a7dc475", size = 30532 },
+]
+
+[[package]]
+name = "openinference-semantic-conventions"
+version = "0.1.30"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/51/8ba1182ee86fc79793d5ff2d11e7fdcda10ded2d01f3e46ca6fcf0568213/openinference_semantic_conventions-0.1.30.tar.gz", hash = "sha256:81fece76e09c83789e35c393b8b30523481eeabf1008745b955631a53e3221d9", size = 13391 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/76/5b7e78cf0de38589b821bbe8e9c29c59a6e76edfb980488d0854cbb90f7c/openinference_semantic_conventions-0.1.30-py3-none-any.whl", hash = "sha256:36d946d3f95f699b7c4b12324ae9c1f02d6c7750df11eece56aa159cff430b3d", size = 10911 },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/83/6dba32b85f31868400440dc7ad2ca1eab94cbbf3a7b0459ed39f8311a9e2/opentelemetry_api-1.43.0-py3-none-any.whl", hash = "sha256:20acf45e9b21851926835292e4045d290acade1edd2ff3de86d2f069687ba1fd", size = 61912 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795 },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/0c/cb9fe342de5299c7af24582eb7d788661cc53a1c4b904da92309caaa9417/opentelemetry_instrumentation-0.64b0-py3-none-any.whl", hash = "sha256:133ab7ffca796557aec059bf6be3190a34b6dea987f25be3d9409e230cbdad8b", size = 35880 },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/a7/3e5308cf548b8f72529c7db1afdb3a404211982376a12927fd7759f77bf3/opentelemetry_proto-1.43.0-py3-none-any.whl", hash = "sha256:c58f1f7ef84bc7dc2834016c0c37fe0081dde7ca9f6339be1970fbf9cdaaa90d", size = 72489 },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.43.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/e3/b17be23af124201c9f52eececd4cc8ddfed1597d37b4ee771895d325805c/opentelemetry_sdk-1.43.0-py3-none-any.whl", hash = "sha256:d1323a547c1ce69d6a069a17a44b7da82bb8b332051ecb074041f87642c86823", size = 178852 },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.64b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/ca/23ba87a221b574a7c5a99d48849d80bfe8b047624681357e2b002e566187/opentelemetry_semantic_conventions-0.64b0-py3-none-any.whl", hash = "sha256:ea77e85e354b8f604ddbe5f3d9135216f982fa4d77e5859ac30f6d8a50505aa6", size = 203713 },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -493,7 +643,7 @@ wheels = [
 
 [[package]]
 name = "parsehawk"
-version = "0.1.0"
+version = "0.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },
@@ -507,6 +657,13 @@ dependencies = [
     { name = "pypdfium2" },
     { name = "python-multipart" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+tracing = [
+    { name = "openinference-instrumentation-openai" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
 ]
 
 [package.dev-dependencies]
@@ -525,6 +682,9 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "openai", specifier = ">=2.44.0" },
+    { name = "openinference-instrumentation-openai", marker = "extra == 'tracing'", specifier = ">=0.1.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", marker = "extra == 'tracing'", specifier = ">=1.27.0" },
+    { name = "opentelemetry-sdk", marker = "extra == 'tracing'", specifier = ">=1.27.0" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "posthog", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.9.0" },
@@ -533,6 +693,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
+provides-extras = ["tracing"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -628,6 +789,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472 },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226 },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847 },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030 },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130 },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945 },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996 },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659 },
 ]
 
 [[package]]
@@ -1203,4 +1379,35 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/8f/aea9c71cc92bf9b6cc0f7f70df8f0b420636b6c96ef4feee1e16f80f75dd/websockets-16.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0298d07ee155e2e9fda5be8a9042200dd2e3bb0b8a38482156576f863a9d457c", size = 176968 },
     { url = "https://files.pythonhosted.org/packages/9a/3f/f70e03f40ffc9a30d817eef7da1be72ee4956ba8d7255c399a01b135902a/websockets-16.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:a653aea902e0324b52f1613332ddf50b00c06fdaf7e92624fbf8c77c78fa5767", size = 178735 },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598 },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782 },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678 },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671 },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785 },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699 },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695 },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813 },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809 },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414 },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368 },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489 },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484 },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151 },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828 },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544 },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663 },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387 },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849 },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147 },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734 },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585 },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553 },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460 },
 ]


### PR DESCRIPTION
Closes #24

## What

- **Backend-agnostic OTLP tracing for LM requests.** All providers go through the OpenAI SDK, so tracing is OpenInference auto-instrumentation of that client exporting standard OTLP. The api/worker consume only the four OTel-standard env vars (`OTEL_SDK_DISABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SERVICE_NAME`) — point them at any collector.
- **Bundled Arize Phoenix as the default target**, built from `services/phoenix/Dockerfile.phoenix` behind a compose profile. Traces persist in Phoenix's own SQLite DB under `data/phoenix/` (deliberately not `parsehawk.db`: separate schema migrations, single-writer lock, independent lifecycle).
- **Default-on with `-x phoenix` opt-out.** `parsehawk start` brings Phoenix up (UI at `http://127.0.0.1:6006`); `-x phoenix` skips it and disables tracing unless the operator explicitly set their own `OTEL_*` collector. Startup waits for Phoenix non-fatally — a broken tracing backend never blocks the app.
- **Phoenix itself is configurable** via its native `PHOENIX_*` vars (retention, Prometheus, auth, Postgres) plus an optional gitignored `phoenix.env` for the long tail (OAuth2/LDAP/…). Enabling auth needs no app change: set `PHOENIX_ENABLE_AUTH`/`PHOENIX_SECRET`, create an API key, and pass `OTEL_EXPORTER_OTLP_HEADERS="authorization=Bearer <key>"`.
- Tracing deps live in an optional `tracing` extra (installed in the Docker image and dev/CI via `--all-extras`); the module mirrors `telemetry.py`'s defensive design — any failure degrades to a no-op.

Full design rationale: see the [plan on the issue](https://github.com/parsehawk/parsehawk/issues/24#issuecomment-4852397404).

## Verification

**macOS Apple Silicon (vLLM Metal)** — full local runtime path per AGENTS.md:
- `just format-check lint typecheck` ✅ · 240 unit/integration tests, 100 % coverage gate ✅ · `parsehawk restart` + `just e2e` 17/17 ✅
- Real extraction produced a `ChatCompletion` span (model, token counts) visible in Phoenix; spans survive a full stop/start cycle
- `-x phoenix`: no phoenix container, `OTEL_SDK_DISABLED=true` on api/worker, `parsehawk stop` removes the profiled container
- Compose config validated with/without the profile and with auth-env overrides; `PHOENIX_SECRET`/`OTEL_EXPORTER_OTLP_HEADERS` use pass-through because Phoenix rejects a set-but-empty secret

**Linux x86_64 + NVIDIA (Docker vLLM runtime): not verified** — no such host available in this session; @benemanu will test on the Linux + NVIDIA stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)