### PR TITLE
docs: add contributor guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,10 +5,22 @@ for changes to the Apache-2.0 open-source core.
 
 ## Maintainers
 
-ParseHawk is maintained by Francis Rafal and the ParseHawk maintainers. Maintainers
-review issues and pull requests, make release decisions, and keep the open-source
-core clearly separated from any future hosted cloud, enterprise, or
-source-available work.
+Maintainers review issues and pull requests, make release decisions, and keep
+the open-source core clearly separated from any future hosted cloud, enterprise,
+or source-available work.
+
+- Simon Hoffmann - Maintainer
+
+  GitHub: [@simx11](https://github.com/simx11)
+
+- Francis Rafal - Maintainer
+
+  GitHub: [@francisrafal](https://github.com/francisrafal) · X:
+  [@francisrafal](https://x.com/francisrafal)
+
+- Benedikt Hielscher - Maintainer
+
+  GitHub: [@benemanu](https://github.com/benemanu)
 
 ## Contribution Terms
 
@@ -182,9 +194,9 @@ literal `\n` escape sequences.
 
 ## Credit
 
-Contributors are credited through the GitHub issue, pull request, and commit
-history. For larger changes, maintainers may also mention contributors in release
-notes or project documentation.
+We plan to credit all contributors in the README. That contributor list is
+tracked separately from this guide; until then, GitHub issues, pull requests,
+and commit history remain the source of truth for contribution attribution.
 
 ## Getting Help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,20 @@ Development requires:
 - `git`
 - `just`
 - `uv`
+- `node`
 - `pnpm`
+- Docker
 
 `pnpm` is required for the standard development workflow because the Web UI
 typecheck, tests, build, and pre-commit hooks use it. Backend-only changes may
 not need `pnpm` for every edit-test loop, but a PR-ready checkout should have it
 installed.
+
+Docker is part of the development toolchain so contributors can build images and
+run the local stack:
+
+- macOS: Docker Desktop
+- Linux: Docker Engine and Docker Compose
 
 Clone the repository and install dependencies:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,191 @@
+# Contributing to ParseHawk
+
+Thanks for helping improve ParseHawk. This guide explains the workflow we expect
+for changes to the Apache-2.0 open-source core.
+
+## Maintainers
+
+ParseHawk is maintained by Francis Rafal and the ParseHawk maintainers. Maintainers
+review issues and pull requests, make release decisions, and keep the open-source
+core clearly separated from any future hosted cloud, enterprise, or
+source-available work.
+
+## Contribution Terms
+
+Unless another written agreement says otherwise, contributions submitted to this
+repository are accepted under the Apache-2.0 license used by the project.
+
+By opening a pull request, you confirm that you have the right to contribute the
+code, documentation, tests, and other materials in that pull request under those
+terms. Do not include proprietary data, customer documents, secrets, private
+model outputs, or assets that cannot be redistributed under the project license.
+
+ParseHawk may later offer hosted cloud or enterprise products built around the
+open-source core. The open-source core remains Apache-2.0, and any future
+enterprise or source-available areas should be documented separately.
+
+## Local Setup
+
+Development requires:
+
+- `git`
+- `just`
+- `uv`
+- `pnpm`
+
+`pnpm` is required for the standard development workflow because the Web UI
+typecheck, tests, build, and pre-commit hooks use it. Backend-only changes may
+not need `pnpm` for every edit-test loop, but a PR-ready checkout should have it
+installed.
+
+Clone the repository and install dependencies:
+
+```bash
+git clone https://github.com/parsehawk/parsehawk.git
+cd parsehawk
+just setup
+```
+
+`just setup` runs `uv sync --all-extras`, installs web dependencies with `pnpm`,
+and installs the pre-commit hooks. It first checks that required development
+tools are available and prints install links for anything missing; it does not
+install system-level tools globally.
+
+If you use the installed `parsehawk` CLI from this checkout, install it as an
+editable tool:
+
+```bash
+uv tool install --editable .
+```
+
+After pulling a change that adds or updates Python dependencies, refresh the
+editable tool environment:
+
+```bash
+uv tool install --force --editable .
+```
+
+## Development Commands
+
+Use the `justfile` recipes as the source of truth for local development.
+
+```bash
+just start          # product-like Docker mode
+just dev            # local-source development mode with reload
+just worker         # run the worker process directly
+just web-dev        # Web UI dev server only
+```
+
+You can also run the CLI commands directly:
+
+```bash
+parsehawk dev
+parsehawk dev -x runtime    # API and Web UI without the bundled runtime
+parsehawk start
+parsehawk start -x runtime  # API and Web UI without the bundled runtime
+```
+
+Quality checks:
+
+```bash
+just format         # format Python with Ruff
+just format-check   # check Python formatting
+just lint           # Ruff linting
+just typecheck      # ty type checking
+just test           # Python tests with coverage gate
+just test-unit      # Python unit tests only
+just web-typecheck  # TypeScript checks
+just web-test       # Web UI tests
+just web-build      # production Web UI build
+just check          # standard Python and web checks
+just hooks-run      # run pre-commit on all files
+```
+
+The Python test configuration enforces 100% coverage for:
+
+- `parsehawk.core.domain`
+- `parsehawk.core.application`
+
+Changes in those packages should keep that coverage at 100%. If your change adds
+domain or application behavior, add focused tests with the implementation.
+
+Pre-commit hooks are not installed automatically by Git. Run `just setup` once
+per clone, or run `just hooks-install` if dependencies are already installed.
+The hooks run Ruff, ty, Python tests, Web UI typecheck, and Web UI tests. CI
+should still run the same checks; hooks are just the fast local feedback loop.
+
+## End-to-End Verification
+
+Most documentation, UI-only, and narrow unit-tested changes do not need the full
+runtime path. For changes that affect runtime startup, model serving, extraction
+behavior, Docker Compose, platform detection, or end-to-end workflows, verify the
+local runtime path before asking for review:
+
+```bash
+parsehawk restart
+just e2e
+```
+
+When feasible, run that verification on both supported local-runtime platforms:
+
+- macOS Apple Silicon, which uses vLLM Metal on the host
+- Linux with an NVIDIA GPU, which uses the Docker Compose vLLM runtime service
+
+If one platform is not available, say so in the pull request.
+
+## Pull Request Workflow
+
+1. Open or find an issue before starting substantial work.
+2. Create a short-lived branch from the latest `main`.
+3. Keep the branch focused on one logical change.
+4. Include tests or documentation updates that match the behavior you changed.
+5. Run the relevant local checks before opening the pull request.
+6. Reference the issue in the pull request title or body, for example
+   `Closes #76`.
+7. Describe what changed, why it changed, and which checks you ran.
+
+This repository uses trunk-based development. Do not merge feature branches into
+`main` directly from a local checkout. Maintainers integrate through pull
+requests, after the branch is rebased on the latest `origin/main`; GitHub's
+rebase-merge should be used to land the change on `main`.
+
+## Commit Messages
+
+Use conventional commits and keep commits atomic. The subject should say what
+changed, and the body should explain why this implementation is the right shape.
+
+Recommended commit types:
+
+- `docs(...)` for documentation-only changes
+- `feat(...)` for user-facing or developer-facing functionality
+- `fix(...)` for bug fixes
+- `chore(...)` for maintenance that does not change behavior
+
+Suggested format:
+
+```text
+<type>(<scope>): <description>
+
+<why this change is needed and why this implementation is appropriate>
+```
+
+For multi-line commit messages, use real newlines in the body. Do not use
+literal `\n` escape sequences.
+
+## Credit
+
+Contributors are credited through the GitHub issue, pull request, and commit
+history. For larger changes, maintainers may also mention contributors in release
+notes or project documentation.
+
+## Getting Help
+
+If you get stuck, ask in the GitHub issue or pull request you are working from.
+For broader questions, open a new issue with:
+
+- what you are trying to do
+- what you expected to happen
+- what happened instead
+- relevant commands, logs, screenshots, or environment details
+
+Please redact secrets, customer data, and private documents before posting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,9 @@ Pre-commit hooks are not installed automatically by Git. Run `just setup` once
 per clone, or run `just hooks-install` if dependencies are already installed.
 The hooks run Ruff, ty, Python tests, Web UI typecheck, and Web UI tests. CI
 should still run the same checks; hooks are just the fast local feedback loop.
+Because `pre-commit` is installed in the project `uv` environment, run it via
+`just hooks-run` or `uv run pre-commit run --all-files` instead of calling
+`pre-commit` directly.
 
 ## End-to-End Verification
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="#first-extraction">First extraction</a> ·
   <a href="#api-cli-and-web-ui">API, CLI, and Web UI</a> ·
   <a href="#requirements">Requirements</a> ·
-  <a href="#development">Development</a>
+  <a href="#contributing">Contributing</a>
 </p>
 
 ParseHawk turns PDFs, scans, images, text files, and Markdown into structured
@@ -601,79 +601,11 @@ serving from already-open SQLite handles. `parsehawk start` refuses to start
 when target ports are already occupied without a live state file. In that case,
 stop the process using the port and start again.
 
-## Development
+## Contributing
 
-Development requires:
-
-- `git`
-- `just`
-- `uv`
-- `pnpm`
-
-Useful commands:
-
-```bash
-just setup          # install dependencies and pre-commit hooks
-just start          # product-like Docker mode
-just dev            # local-source development mode
-just web-dev        # Web UI dev server only
-just smoke          # local smoke flow
-just test           # Python tests
-just e2e            # local end-to-end API tests (needs the model runtime up)
-just format         # format Python
-just lint           # Ruff linting
-just typecheck      # ty type checking
-just web-typecheck  # TypeScript checks
-just web-test       # Web UI tests
-just web-build      # production Web UI build
-just check          # all standard checks
-just hooks-run      # run pre-commit on all files
-```
-
-Pre-commit hooks are not installed automatically by Git. Run this once per
-clone:
-
-```bash
-just setup
-```
-
-The hooks run Ruff, ty, Python tests, Web UI typecheck, and Web UI tests. CI
-should still run the same checks; hooks are just the fast local feedback loop.
-
-#### Upgrading an editable tool install
-
-`parsehawk` installed with `uv tool install --editable .` runs from its own tool
-environment, which `uv sync` does not update. After pulling changes that add or
-bump a dependency, refresh the tool so the CLI picks them up:
-
-```bash
-uv tool install --force --editable .
-```
-
-A stale tool environment surfaces as a `ModuleNotFoundError` for a newly added
-dependency when you run `parsehawk`.
-
-#### Development mode:
-
-Includes hot reload for the web UI.
-
-```bash
-parsehawk dev
-```
-
-```bash
-parsehawk dev -x runtime  # starts the API and Web UI without the bundled runtime
-```
-
-#### Product-like local mode:
-
-```bash
-parsehawk start
-```
-
-```bash
-parsehawk start -x runtime  # starts the API and Web UI without the bundled runtime
-```
+ParseHawk welcomes issues and pull requests. For local development setup,
+quality checks, pull request expectations, coverage requirements, and licensing
+terms, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Troubleshooting
 

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -1,5 +1,44 @@
 import "@testing-library/jest-dom/vitest";
 
+function createStorageMock(): Storage {
+  const values = new Map<string, string>();
+
+  return {
+    get length() {
+      return values.size;
+    },
+    clear() {
+      values.clear();
+    },
+    getItem(key: string) {
+      return values.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(values.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      values.delete(key);
+    },
+    setItem(key: string, value: string) {
+      values.set(key, value);
+    }
+  };
+}
+
+function hasUsableLocalStorage() {
+  try {
+    return typeof window.localStorage !== "undefined";
+  } catch {
+    return false;
+  }
+}
+
+if (!hasUsableLocalStorage()) {
+  const storage = createStorageMock();
+  Object.defineProperty(window, "localStorage", { value: storage, configurable: true });
+  Object.defineProperty(globalThis, "localStorage", { value: storage, configurable: true });
+}
+
 class ResizeObserverMock {
   observe() {}
   unobserve() {}

--- a/justfile
+++ b/justfile
@@ -51,13 +51,13 @@ web-dev:
     pnpm --dir apps/web dev
 
 web-build:
-    pnpm --dir apps/web build
+    CI=true pnpm --dir apps/web build
 
 web-test:
-    pnpm --dir apps/web test
+    CI=true pnpm --dir apps/web test
 
 web-typecheck:
-    pnpm --dir apps/web typecheck
+    CI=true pnpm --dir apps/web typecheck
 
 check: format-check lint typecheck test web-typecheck web-test web-build
 

--- a/justfile
+++ b/justfile
@@ -3,7 +3,25 @@ set dotenv-load := true
 export PARSEHAWK_DATA_DIR := env_var_or_default("PARSEHAWK_DATA_DIR", "data")
 export PARSEHAWK_DATABASE_PATH := env_var_or_default("PARSEHAWK_DATABASE_PATH", "data/parsehawk.db")
 
-setup:
+check-prereqs:
+    @missing=0; \
+    for cmd in git uv pnpm; do \
+        if ! command -v "$cmd" >/dev/null 2>&1; then \
+            echo "Missing required development tool: $cmd"; \
+            missing=1; \
+        fi; \
+    done; \
+    if [ "$missing" -ne 0 ]; then \
+        echo ""; \
+        echo "Install the missing tool(s), then rerun 'just setup'."; \
+        echo "Install guides:"; \
+        echo "  just: https://just.systems/man/en/packages.html"; \
+        echo "  uv: https://docs.astral.sh/uv/getting-started/installation/"; \
+        echo "  pnpm: https://pnpm.io/installation"; \
+        exit 1; \
+    fi
+
+setup: check-prereqs
     uv sync --all-extras
     pnpm install
     uv run pre-commit install

--- a/justfile
+++ b/justfile
@@ -3,33 +3,24 @@ set dotenv-load := true
 export PARSEHAWK_DATA_DIR := env_var_or_default("PARSEHAWK_DATA_DIR", "data")
 export PARSEHAWK_DATABASE_PATH := env_var_or_default("PARSEHAWK_DATABASE_PATH", "data/parsehawk.db")
 
+default:
+    @just --list
+
 check-prereqs:
-    @missing=0; \
-    for cmd in git uv pnpm; do \
-        if ! command -v "$cmd" >/dev/null 2>&1; then \
-            echo "Missing required development tool: $cmd"; \
-            missing=1; \
-        fi; \
-    done; \
-    if [ "$missing" -ne 0 ]; then \
-        echo ""; \
-        echo "Install the missing tool(s), then rerun 'just setup'."; \
-        echo "Install guides:"; \
-        echo "  just: https://just.systems/man/en/packages.html"; \
-        echo "  uv: https://docs.astral.sh/uv/getting-started/installation/"; \
-        echo "  pnpm: https://pnpm.io/installation"; \
-        exit 1; \
-    fi
+    @scripts/check-dev-prereqs.sh
+
+check-runtime-prereqs:
+    @scripts/check-dev-prereqs.sh --runtime
 
 setup: check-prereqs
     uv sync --all-extras
     pnpm install
     uv run pre-commit install
 
-start:
+start: check-runtime-prereqs
     uv run parsehawk start
 
-dev:
+dev: check-runtime-prereqs
     uv run parsehawk dev --reload
 
 worker:

--- a/scripts/check-dev-prereqs.sh
+++ b/scripts/check-dev-prereqs.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+include_runtime=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --runtime)
+      include_runtime=1
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+missing=0
+
+check_required() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "Missing required development tool: $command_name"
+    missing=1
+  fi
+}
+
+check_required git
+check_required just
+check_required uv
+check_required node
+check_required pnpm
+check_required docker
+
+if [ "$include_runtime" -eq 1 ]; then
+  if command -v docker >/dev/null 2>&1 && ! docker compose version >/dev/null 2>&1; then
+    echo "Missing required runtime tool: docker compose"
+    missing=1
+  fi
+fi
+
+if [ "$missing" -ne 0 ]; then
+  echo ""
+  echo "Install the missing tool(s), then rerun the command."
+  echo "Install guides:"
+  echo "  just: https://just.systems/man/en/packages.html"
+  echo "  uv: https://docs.astral.sh/uv/getting-started/installation/"
+  echo "  Node.js: https://nodejs.org/en/download"
+  echo "  pnpm: https://pnpm.io/installation"
+  if [ "$include_runtime" -eq 1 ]; then
+    echo "  Docker: https://docs.docker.com/get-started/get-docker/"
+  fi
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Closes #76.

- Add a contributor-facing `CONTRIBUTING.md` with maintainers, setup, development commands, PR workflow, conventional commits, coverage expectations, runtime verification guidance, credit notes, and Apache-2.0 contribution terms.
- Keep the README user-facing by replacing the detailed development section with a concise contributor pointer.
- Add a default `just` recipe, move development prerequisite checks into `scripts/check-dev-prereqs.sh`, and make web check recipes safe for non-interactive pre-commit runs.
- Harden the Vitest setup with a test-only `localStorage` fallback for Node runtimes where jsdom does not expose usable local storage by default.

## Validation

- `git fetch origin && git rebase origin/main`
- `just check`
- `uv run pre-commit run --all-files`
- `just check-prereqs` with normal PATH reports missing `pnpm` before it was installed; with `pnpm` installed it passes.

## Notes

- Full runtime verification with `parsehawk restart` and `just e2e` was not run because this PR does not change runtime startup, model serving, extraction behavior, Docker Compose behavior, platform detection, or end-to-end extraction workflows.