### PR TITLE
docs: add README community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
   <a href="#first-extraction">First extraction</a> ·
   <a href="#api-cli-and-web-ui">API, CLI, and Web UI</a> ·
   <a href="#requirements">Requirements</a> ·
-  <a href="#contributing">Contributing</a>
+  <a href="#community">Community</a>
 </p>
 
 ParseHawk turns PDFs, scans, images, text files, and Markdown into structured
@@ -601,12 +601,6 @@ serving from already-open SQLite handles. `parsehawk start` refuses to start
 when target ports are already occupied without a live state file. In that case,
 stop the process using the port and start again.
 
-## Contributing
-
-ParseHawk welcomes issues and pull requests. For local development setup,
-quality checks, pull request expectations, coverage requirements, and licensing
-terms, see [CONTRIBUTING.md](CONTRIBUTING.md).
-
 ## Troubleshooting
 
 Start with the built-in health checks:
@@ -643,6 +637,22 @@ parsehawk start
 
 If the Model Runtime is slow to become ready, give it a few minutes on first
 startup while vLLM loads model weights, profiles memory, and warms kernels.
+
+## Community
+
+Contributions are welcome. Whether you are fixing a bug, improving docs, adding
+tests, or proposing a feature, thank you for helping make ParseHawk better.
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for local development setup, pull request
+expectations, coverage requirements, and licensing terms for the Apache-2.0
+open-source core.
+
+Thank you to all ParseHawk contributors. Every issue, pull request, review,
+bug report, docs fix, and idea helps move the project forward.
+
+<a href="https://github.com/parsehawk/parsehawk/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=parsehawk/parsehawk" alt="ParseHawk contributors">
+</a>
 
 ## Credits
 


### PR DESCRIPTION
## Summary

Closes #75.

- Add a bottom `Community` section to the README inspired by OpenClaw's README structure.
- Explicitly thank ParseHawk contributors for issues, pull requests, reviews, bug reports, docs fixes, and ideas.
- Link to `CONTRIBUTING.md` and show automatically maintained contributor avatars via `contrib.rocks`.
- Update the README top navigation to point to `Community`.

## Validation

- `git fetch origin && git rebase origin/main`
- `just check`
- `uv run pre-commit run --all-files`
- `curl -I -L https://contrib.rocks/image?repo=parsehawk/parsehawk` returned `200` SVG

## Notes

- Full runtime verification with `parsehawk restart` and `just e2e` was not run because this is a README-only documentation change.