### PR TITLE
fix(tracing): record OpenAI extra body metadata

### DIFF
--- a/src/parsehawk/server/runtime/inference/openai_engine.py
+++ b/src/parsehawk/server/runtime/inference/openai_engine.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import json
 import logging
+from contextlib import nullcontext
 from dataclasses import dataclass
 from time import monotonic
 from typing import Any, Callable
 
 from openai import APIConnectionError, APIStatusError, OpenAI
 
+from parsehawk import tracing
 from parsehawk.core.application.ports import ExtractionRequest, ExtractionResponse
 from parsehawk.core.domain.errors import ExtractionCancelled, ProviderRequestError
 from parsehawk.core.domain.models import NUEXTRACT3_MODELS
@@ -137,30 +139,34 @@ class OpenAIExtractionEngine:
         call_kwargs["stream"] = True
         self._debug_model_io("model runtime request: %s", call_kwargs)
         try:
-            stream = self._client.chat.completions.create(**call_kwargs)
-            content_parts: list[str] = []
-            reasoning_parts: list[str] = []
-            next_cancellation_check_at = monotonic()
-            try:
-                for chunk in stream:
-                    now = monotonic()
-                    if now >= next_cancellation_check_at:
-                        cancellation_check()
-                        next_cancellation_check_at = now + CANCELLATION_CHECK_INTERVAL_SECONDS
-                    chunk_data = chunk.model_dump()
-                    choice = (chunk_data.get("choices") or [{}])[0]
-                    delta = choice.get("delta") or {}
-                    content = delta.get("content")
-                    if isinstance(content, str):
-                        content_parts.append(content)
-                    for field in ("reasoning", "reasoning_content"):
-                        reasoning = delta.get(field)
-                        if isinstance(reasoning, str):
-                            reasoning_parts.append(reasoning)
-            finally:
-                close = getattr(stream, "close", None)
-                if close is not None:
-                    close()
+            extra_body_context = (
+                tracing.openai_extra_body_context(extra_body) if extra_body else nullcontext()
+            )
+            with extra_body_context:
+                stream = self._client.chat.completions.create(**call_kwargs)
+                content_parts: list[str] = []
+                reasoning_parts: list[str] = []
+                next_cancellation_check_at = monotonic()
+                try:
+                    for chunk in stream:
+                        now = monotonic()
+                        if now >= next_cancellation_check_at:
+                            cancellation_check()
+                            next_cancellation_check_at = now + CANCELLATION_CHECK_INTERVAL_SECONDS
+                        chunk_data = chunk.model_dump()
+                        choice = (chunk_data.get("choices") or [{}])[0]
+                        delta = choice.get("delta") or {}
+                        content = delta.get("content")
+                        if isinstance(content, str):
+                            content_parts.append(content)
+                        for field in ("reasoning", "reasoning_content"):
+                            reasoning = delta.get(field)
+                            if isinstance(reasoning, str):
+                                reasoning_parts.append(reasoning)
+                finally:
+                    close = getattr(stream, "close", None)
+                    if close is not None:
+                        close()
         except APIStatusError as exc:
             message = getattr(exc, "message", str(exc))
             raise ProviderRequestError(

--- a/src/parsehawk/tracing.py
+++ b/src/parsehawk/tracing.py
@@ -29,6 +29,8 @@ from __future__ import annotations
 
 import logging
 import os
+from contextlib import nullcontext
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +70,17 @@ def configure_tracing(*, service_name: str) -> None:
         _register(service_name)
     except Exception:  # pragma: no cover - defensive; tracing must never break a Run
         logger.debug("tracing: failed to configure OTLP tracing", exc_info=True)
+
+
+def openai_extra_body_context(extra_body: dict[str, Any]):
+    """Attach OpenAI-compatible extension fields to OpenInference request spans."""
+    if not extra_body or tracing_disabled():
+        return nullcontext()
+    try:
+        from openinference.instrumentation import using_metadata
+    except Exception:
+        return nullcontext()
+    return using_metadata({"parsehawk.openai.extra_body": extra_body})
 
 
 def _register(service_name: str) -> None:

--- a/tests/unit/server/test_openai_engine.py
+++ b/tests/unit/server/test_openai_engine.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 from typing import Any, cast
 
 import httpx
@@ -135,6 +136,53 @@ def test_nuextract_adapter_sends_chat_template_kwargs_in_extra_body() -> None:
     assert call["model"] == NUEXTRACT_MODEL
     assert call["extra_body"]["chat_template_kwargs"]["template"]
     assert call["response_format"]["type"] == "json_schema"
+
+
+def test_nuextract_adapter_records_extra_body_for_tracing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[dict[str, Any]] = []
+
+    @contextmanager
+    def fake_extra_body_context(extra_body: dict[str, Any]):
+        recorded.append(extra_body)
+        yield
+
+    monkeypatch.setattr(
+        openai_engine_module.tracing, "openai_extra_body_context", fake_extra_body_context
+    )
+    client, completions = _client_returning('{"receipt_id": "2"}')
+    engine = OpenAIExtractionEngine(
+        OpenAIEngineConfig(model=NUEXTRACT_MODEL), client=cast(OpenAI, client)
+    )
+
+    engine.extract(make_request())
+
+    assert recorded == [completions.calls[0]["extra_body"]]
+    assert recorded[0]["chat_template_kwargs"]["instructions"] == "Extract the receipt id."
+
+
+def test_generic_adapter_records_no_extra_body_for_tracing_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    recorded: list[dict[str, Any]] = []
+
+    @contextmanager
+    def fake_extra_body_context(extra_body: dict[str, Any]):
+        recorded.append(extra_body)
+        yield
+
+    monkeypatch.setattr(
+        openai_engine_module.tracing, "openai_extra_body_context", fake_extra_body_context
+    )
+    client, _ = _client_returning('{"receipt_id": "2"}')
+    engine = OpenAIExtractionEngine(
+        OpenAIEngineConfig(model="gpt-4o-mini"), client=cast(OpenAI, client)
+    )
+
+    engine.extract(make_request())
+
+    assert recorded == []
 
 
 def test_generic_adapter_builds_system_prompt_without_nuextract_kwargs() -> None:

--- a/tests/unit/test_tracing.py
+++ b/tests/unit/test_tracing.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from types import ModuleType
+
 import pytest
 
 from parsehawk import tracing
@@ -70,3 +73,37 @@ def test_configure_tracing_swallows_registration_errors(
     monkeypatch.setattr(tracing, "_register", _boom)
 
     tracing.configure_tracing(service_name="parsehawk-api")
+
+
+def test_openai_extra_body_context_uses_openinference_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    contexts: list[dict[str, object]] = []
+    extra_body = {
+        "chat_template_kwargs": {
+            "instructions": "Extract receipt fields.",
+            "template": '{"receipt_id": "string"}',
+            "enable_thinking": False,
+        }
+    }
+    module = ModuleType("openinference.instrumentation")
+
+    def fake_using_metadata(metadata: dict[str, object]) -> _FakeMetadataContext:
+        contexts.append(metadata)
+        return _FakeMetadataContext()
+
+    setattr(module, "using_metadata", fake_using_metadata)
+    monkeypatch.setitem(sys.modules, "openinference.instrumentation", module)
+
+    with tracing.openai_extra_body_context(extra_body):
+        pass
+
+    assert contexts == [{"parsehawk.openai.extra_body": extra_body}]
+
+
+class _FakeMetadataContext:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *args: object) -> None:
+        return None


### PR DESCRIPTION
## Summary

- attach OpenAI SDK `extra_body` payloads to OpenInference metadata so Phoenix shows NuExtract/vLLM `chat_template_kwargs` on the `ChatCompletion` span
- avoid creating a separate ParseHawk span or duplicating template/instruction fields across several attributes
- cover the NuExtract tracing path and the generic-model no-op path in unit tests

## Root Cause

ParseHawk sends NuExtract-specific vLLM fields through the OpenAI SDK `extra_body` option. The OpenInference OpenAI instrumentation records the SDK's standard chat-completion JSON body, but `extra_body` lives in request options and was omitted from Phoenix traces. This made NuExtract traces look like they had no template or instructions even though vLLM received them.

Closes #84

## Validation

- `uv run pytest tests/unit/server/test_openai_engine.py tests/unit/test_tracing.py --no-cov`
- `uv run ruff check src/parsehawk/tracing.py src/parsehawk/server/runtime/inference/openai_engine.py tests/unit/server/test_openai_engine.py tests/unit/test_tracing.py`
- `just test`
- `parsehawk restart`
- `parsehawk extract --text ... --schema tests/fixtures/receipt/receipt_schema.json --wait --timeout-seconds 180`
- verified Phoenix stored `metadata.parsehawk.openai.extra_body` on the newest `ChatCompletion` span
