### PR TITLE
feat: CI license compliance — dependency gate + bundled-image guard

### DIFF
--- a/.github/workflows/ci-checks.yaml
+++ b/.github/workflows/ci-checks.yaml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       lint: ${{ steps.filter.outputs.lint }}
       web: ${{ steps.filter.outputs.web }}
+      licenses: ${{ steps.filter.outputs.licenses }}
     steps:
       - name: Detect changed areas
         uses: dorny/paths-filter@v3
@@ -43,6 +44,26 @@ jobs:
               - 'apps/web/**'
               - 'pnpm-lock.yaml'
               - 'pnpm-workspace.yaml'
+              - '.github/workflows/ci-checks.yaml'
+            licenses:
+              - 'uv.lock'
+              - 'pyproject.toml'
+              - 'pnpm-lock.yaml'
+              - 'apps/web/package.json'
+              - '.trivyaml'
+              - 'licenses/**'
+              - 'scripts/check_dep_licenses.py'
+              - 'scripts/dep_license_exceptions.txt'
+              - 'scripts/check_bundled_images.py'
+              # The image guard scans the whole repo, so trigger on any
+              # Dockerfile or Compose file wherever it lives.
+              - '**/Dockerfile*'
+              - '**/dockerfile*'
+              - '**/docker-compose*.yml'
+              - '**/docker-compose*.yaml'
+              - '**/compose*.yml'
+              - '**/compose*.yaml'
+              - 'justfile'
               - '.github/workflows/ci-checks.yaml'
 
   hygiene:
@@ -64,7 +85,7 @@ jobs:
       # SKIP list in sync with the hooks in .pre-commit-config.yaml.
       - name: Run hygiene hooks
         env:
-          SKIP: ruff-format,ruff-check,ty-check,unit-tests,web-typecheck,web-tests
+          SKIP: ruff-format,ruff-check,ty-check,unit-tests,web-typecheck,web-tests,licenses-manifest,licenses-deps
         run: uvx pre-commit run --all-files --show-diff-on-failure
 
   lint:
@@ -94,7 +115,7 @@ jobs:
       # .pre-commit-config.yaml.
       - name: Run pre-commit (ruff + ty)
         env:
-          SKIP: check-toml,check-yaml,end-of-file-fixer,trailing-whitespace,unit-tests,web-typecheck,web-tests
+          SKIP: check-toml,check-yaml,end-of-file-fixer,trailing-whitespace,unit-tests,web-typecheck,web-tests,licenses-manifest,licenses-deps
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
   web:
@@ -129,3 +150,48 @@ jobs:
 
       - name: Test
         run: just web-test
+
+  licenses:
+    name: license compliance
+    needs: changes
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || needs.changes.outputs.licenses == 'true') }}
+    runs-on: ubuntu-latest
+    env:
+      # osv-scanner surfaces everything outside this permissive allowlist; the real
+      # block/flag/allow decision is made by scripts/check_dep_licenses.py, so this
+      # only needs to be safe, not exhaustive. Keep in sync with justfile.
+      LICENSE_ALLOW: "MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MPL-2.0,0BSD,Python-2.0,PSF-2.0,Unlicense,CC0-1.0,BlueOak-1.0.0,OFL-1.1,Zlib,BSL-1.0,MIT-0,CC-BY-4.0"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # osv-scanner reads uv.lock and pnpm-lock.yaml directly (licenses via
+      # deps.dev), so no uv sync / pnpm install is needed. The checker scripts are
+      # pure stdlib, so only Python 3.11+ (for tomllib) is required.
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install osv-scanner
+        run: |
+          curl -sSfL https://github.com/google/osv-scanner/releases/download/v2.4.0/osv-scanner_linux_amd64 -o /usr/local/bin/osv-scanner
+          chmod +x /usr/local/bin/osv-scanner
+
+      # One pass over both lockfiles. osv exits non-zero when it surfaces anything
+      # outside the allowlist, so tolerate that and let the checker decide.
+      - name: Resolve dependency licenses (both ecosystems)
+        run: osv-scanner scan source --format json --licenses="$LICENSE_ALLOW" --lockfile uv.lock --lockfile pnpm-lock.yaml > osv-licenses.json || true
+
+      # Report-only for the initial rollout so the true baseline surfaces without
+      # blocking; flip to blocking (drop --report-only) once a green run confirms it.
+      - name: Check dependency licenses
+        run: python3 scripts/check_dep_licenses.py --source osv --report-only < osv-licenses.json
+
+      # Bundled/referenced container images. Blocking from day one: this is the
+      # guard for source-available images entering via a Dockerfile FROM or a
+      # Compose image: reference (issue #92).
+      # The heavier in-image drift scan (--scan-images, needs Docker) runs locally
+      # via `just licenses-images`, not on every PR.
+      - name: Check bundled image manifest
+        run: python3 scripts/check_bundled_images.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,3 +52,24 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+
+      # License check (issue #92), offline half: guards that every image a
+      # Dockerfile or Compose file references is in the reviewed manifest. Fast
+      # and network-free, so it runs on every commit.
+      - id: licenses-manifest
+        name: bundled image licenses
+        entry: just licenses-manifest
+        language: system
+        pass_filenames: false
+        always_run: true
+
+      # License check, dependency half: osv-scanner resolves licenses via deps.dev
+      # (network), so it is scoped to lockfile changes rather than always_run —
+      # it fires only when a dependency could have changed, keeping unrelated
+      # (and offline) commits fast and network-free.
+      - id: licenses-deps
+        name: dependency licenses
+        entry: just licenses-deps
+        language: system
+        pass_filenames: false
+        files: ^(uv\.lock|pnpm-lock\.yaml)$

--- a/.trivyaml
+++ b/.trivyaml
@@ -1,0 +1,50 @@
+# Trivy configuration for CONTAINER IMAGE license detection (Tier 2 engine).
+#
+# Trivy is NOT used for dependency licenses here: it does not read license
+# metadata from uv.lock (Python), and Node licenses come cleaner from
+# `pnpm licenses list`. Dependency gating lives in scripts/check_dep_licenses.py.
+# This config's job is to make `trivy image` reliably surface source-available /
+# copyleft licenses inside referenced images (e.g. Elastic-2.0 in the Phoenix
+# image), which scripts/check_bundled_images.py cross-checks against the manifest.
+#
+# Policy (see AGENTS.md / issue #92): the project ships under Apache-2.0.
+#   - forbidden  -> CRITICAL -> a real hit (gate with --severity CRITICAL)
+#   - restricted (incl. LGPL, base-OS GPL) -> HIGH -> noise here, filtered out
+#
+# trivy classifies GPL/AGPL as `restricted` (HIGH) by default, so they are listed
+# explicitly to be promoted to `forbidden` (CRITICAL). Source-available licenses
+# (Elastic-2.0, BUSL, SSPL) are `unknown` to trivy by default, so they must be
+# listed too — verified in Phase 0 against arizephoenix/phoenix:17.20.0, where
+# `Elastic-2.0` was captured but stayed UNKNOWN until listed here.
+
+scan:
+  scanners:
+    - license
+
+license:
+  # Scan license text inside packages, not just declared metadata.
+  full: true
+  # Promote to `forbidden` (CRITICAL). LGPL is intentionally omitted so it stays
+  # `restricted` (HIGH) — reported, not blocked.
+  forbidden:
+    - AGPL-1.0
+    - AGPL-3.0
+    - AGPL-3.0-only
+    - AGPL-3.0-or-later
+    - GPL-1.0
+    - GPL-1.0-only
+    - GPL-1.0-or-later
+    - GPL-2.0
+    - GPL-2.0-only
+    - GPL-2.0-or-later
+    - GPL-3.0
+    - GPL-3.0-only
+    - GPL-3.0-or-later
+    # Source-available (not OSI/Apache-compatible when redistributed):
+    - Elastic-2.0
+    - BUSL-1.1
+    - SSPL-1.0
+    # Non-commercial Creative Commons (incompatible with redistribution):
+    - CC-BY-NC-4.0
+    - CC-BY-NC-SA-4.0
+    - CC-BY-NC-ND-4.0

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -8,6 +8,27 @@ referenced by this repository retain their own licenses. This file documents
 the third-party components that ParseHawk intentionally bundles, builds from, or
 installs through its package manifests and Dockerfiles.
 
+## What ParseHawk redistributes
+
+The only artifact this project publishes is the API/worker container image
+(`ghcr.io/parsehawk/parsehawk`, built from
+[`docker/Dockerfile.api`](docker/Dockerfile.api) by
+`.github/workflows/publish-image.yaml`). It contains ParseHawk's own Apache-2.0
+code, its Python dependencies, and the `python:3.12-slim` (Debian) base.
+Base-OS system packages retain their own licenses (including GPL/LGPL) and are
+redistributed as mere aggregation; they are not linked into ParseHawk's
+Apache-2.0 code. Dependency and image license compatibility is enforced in CI:
+[`licenses/bundled-images.toml`](licenses/bundled-images.toml) is the reviewed
+manifest of every referenced image and how it ships, enforced by
+[`scripts/check_bundled_images.py`](scripts/check_bundled_images.py), and
+packaged dependencies are gated by
+[`scripts/check_dep_licenses.py`](scripts/check_dep_licenses.py).
+
+Everything else is built or pulled by the operator at deploy or run time under
+its own license and is not redistributed by this project: the web UI image
+(built from [`docker/Dockerfile.web`](docker/Dockerfile.web)), the vLLM serving
+runtime, the Arize Phoenix tracing backend, and model weights.
+
 ## Bundled services and container images
 
 ### Arize Phoenix
@@ -39,6 +60,15 @@ ParseHawk Dockerfiles build from these upstream images:
 
 These images and the operating-system packages inside them retain their own
 upstream licenses and notices.
+
+## Model weights
+
+### NuExtract3
+
+The default extraction model, `numind/NuExtract3-W4A16`, is downloaded by the
+model runtime at run time and used under the model provider's license. The
+weights are not part of this repository and are not redistributed by the
+project.
 
 ## Python packages
 

--- a/justfile
+++ b/justfile
@@ -59,7 +59,42 @@ web-test:
 web-typecheck:
     CI=true pnpm --dir apps/web typecheck
 
-check: format-check lint typecheck test web-typecheck web-test web-build
+check: format-check lint typecheck test web-typecheck web-test web-build licenses
+
+# Permissive SPDX ids osv-scanner treats as always-allowed, so it only surfaces the
+# licenses worth adjudicating. The real block/flag/allow decision is made by
+# scripts/check_dep_licenses.py, so this list only needs to be safe, not exhaustive.
+license_allow := "MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MPL-2.0,0BSD,Python-2.0,PSF-2.0,Unlicense,CC0-1.0,BlueOak-1.0.0,OFL-1.1,Zlib,BSL-1.0,MIT-0,CC-BY-4.0"
+
+# License compliance (issue #92): Apache-2.0 shipping surface. Runs both halves.
+licenses: licenses-deps licenses-manifest
+
+# Dependency licenses: osv-scanner reads both uv.lock and pnpm-lock.yaml in one pass
+# (licenses via deps.dev) and feeds one policy in scripts/check_dep_licenses.py.
+# Needs osv-scanner on PATH and network (deps.dev). Locally it degrades to a
+# skip-with-warning when osv-scanner is absent, so `just check` and pre-commit stay
+# green for contributors without it; CI installs osv-scanner and is the authority.
+licenses-deps:
+    #!/usr/bin/env bash
+    set -eu
+    if ! command -v osv-scanner >/dev/null 2>&1; then
+        echo "⚠ osv-scanner not found — skipping dependency license scan (CI runs it)." >&2
+        echo "  install: https://google.github.io/osv-scanner/installation/" >&2
+        exit 0
+    fi
+    osv-scanner scan source --format json --licenses="{{license_allow}}" --lockfile uv.lock --lockfile pnpm-lock.yaml | uv run python scripts/check_dep_licenses.py --source osv
+
+# Bundled-image manifest guard: fails on any Dockerfile FROM or Compose image: ref
+# missing from the reviewed manifest (e.g. the ELv2 Phoenix image), which no
+# dependency scanner sees. Offline and instant (file + TOML parsing only), so it
+# also runs in pre-commit.
+licenses-manifest:
+    uv run python scripts/check_bundled_images.py
+
+# Additionally pull the small referenced images and check for in-image license
+# drift with trivy (catches a vendor relicensing an image). Needs trivy + Docker.
+licenses-images:
+    uv run python scripts/check_bundled_images.py --scan-images
 
 hooks-install:
     uv run pre-commit install

--- a/licenses/bundled-images.toml
+++ b/licenses/bundled-images.toml
@@ -1,0 +1,51 @@
+# Reviewed manifest of every third-party container image referenced by a
+# Dockerfile or Compose file in this repo. scripts/check_bundled_images.py
+# enforces it: any referenced image that is missing here fails CI, forcing a
+# human to record its license and how it ships before merge. This is the guard
+# that catches a source-available image (e.g. Arize Phoenix, ELv2) entering via
+# a Dockerfile `FROM` or a Compose `image:` — where a dependency scanner is
+# blind, because such an image never appears in a lockfile.
+#
+# Fields:
+#   name    bare image repository (no tag/digest), as written in the reference.
+#   license best-effort SPDX id of the image's own software. Base OS images carry
+#           many licenses; record the license that governs *shipping* the image.
+#   ships   how the image reaches users:
+#             redistributed  we push these layers to a registry (GHCR) -> a
+#                            forbidden license here FAILS the check.
+#             runtime-pull   the operator pulls it at deploy time; we do not
+#                            redistribute it -> forbidden license is allowed, but
+#                            must be documented in THIRD_PARTY_NOTICES.md.
+#             build-only     used only in a build stage; not present in any
+#                            shipped layer -> forbidden license is allowed.
+#   note    why this classification holds; keep it truthful and specific.
+
+[[image]]
+name = "python"
+license = "PSF-2.0"
+ships = "redistributed"
+note = "Base of the published API/worker image (docker/Dockerfile.api). Debian slim base; system packages are standard permissive/copyleft OS licenses shipped as mere aggregation."
+
+[[image]]
+name = "node"
+license = "MIT"
+ships = "build-only"
+note = "Build stage that compiles the web UI (docker/Dockerfile.web); not present in the served nginx layer."
+
+[[image]]
+name = "nginx"
+license = "BSD-2-Clause"
+ships = "redistributed"
+note = "Serves the static web UI (docker/Dockerfile.web). Alpine base; OS packages shipped as mere aggregation."
+
+[[image]]
+name = "vllm/vllm-openai"
+license = "Apache-2.0"
+ships = "runtime-pull"
+note = "Model serving runtime (docker/runtime/Dockerfile.linux-vllm, docker/docker-compose.linux.yml), pulled at deploy time. Not redistributed by the project (see publish-image.yaml)."
+
+[[image]]
+name = "arizephoenix/phoenix"
+license = "Elastic-2.0"
+ships = "runtime-pull"
+note = "Optional tracing backend (services/phoenix/Dockerfile.phoenix). Source-available (Elastic License 2.0), pulled by the operator, NOT redistributed by the project. Documented in THIRD_PARTY_NOTICES.md. ELv2 restricts offering it as a managed service."

--- a/scripts/check_bundled_images.py
+++ b/scripts/check_bundled_images.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Enforce the reviewed manifest of bundled/referenced container images.
+
+Dependency scanners only see packaged deps, so a source-available image pulled in
+via a Dockerfile `FROM` or a Compose `image:` (e.g. Arize Phoenix, ELv2) is
+invisible to them. This guard closes that gap: it extracts every image any
+Dockerfile or Compose file in the repo references and checks it against
+licenses/bundled-images.toml, which records each image's license and how it
+ships. It fails when:
+
+  1. novelty      — a referenced image has no manifest entry (forces a human to
+                    classify a newly-added image before merge);
+  2. ship-mode    — a manifest image whose license is disallowed (strong-copyleft
+                    / source-available / non-commercial) is marked `redistributed`
+                    (the same license is fine as `runtime-pull` / `build-only`);
+  3. stale        — a manifest entry no image references any more (warn only).
+
+With --scan-images it additionally pulls the small images and uses trivy to detect
+the license actually inside them, failing on drift from the manifest (catches a
+vendor relicensing an existing image, e.g. Apache -> BUSL). Each image is scanned
+at the tag actually referenced, so the scan tests the artifact in use. vLLM is
+skipped (multi-GB). Requires trivy + a working container runtime.
+
+Known limitation: a Compose service that both `build:`s locally and names its
+output with `image:` will surface as novel (line-based parsing cannot pair the
+two keys). No such service exists today; if one appears, list its first-party
+image in the manifest or teach this parser about the pairing.
+
+The license policy is imported from check_dep_licenses so images and dependencies
+share one source of truth.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from check_dep_licenses import BLOCK, classify  # noqa: E402
+
+REPO = Path(__file__).resolve().parent.parent
+MANIFEST = REPO / "licenses" / "bundled-images.toml"
+# Vendored/generated trees that cannot reference images we ship. Hidden dirs
+# (.git, .venv, ...) are pruned by the leading-dot check in image_files().
+SKIP_DIRS = {"node_modules", "__pycache__", "dist", "build"}
+ALLOWED_SHIPS = {"redistributed", "runtime-pull", "build-only"}
+# Images too large to pull for a content scan; the manifest is authoritative.
+SCAN_SKIP = {"vllm/vllm-openai"}
+
+FROM_RE = re.compile(r"^\s*FROM\s+(?:--platform=\S+\s+)?(\S+)", re.IGNORECASE)
+ARG_RE = re.compile(r"^\s*ARG\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(\S+)", re.IGNORECASE)
+VAR_RE = re.compile(r"\$\{?([A-Za-z_][A-Za-z0-9_]*)\}?")
+COMPOSE_FILE_RE = re.compile(r"(docker-)?compose[^/]*\.ya?ml")
+IMAGE_KEY_RE = re.compile(r"^\s*image:\s*[\"']?([^\"'\s#]+)")
+# Compose interpolation with a default: ${VAR:-default} / ${VAR-default}.
+COMPOSE_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::?-([^}]*))?\}")
+
+
+def bare_name(image_ref: str) -> str:
+    """Strip tag and digest, keep repository (incl. any registry/namespace)."""
+    ref = image_ref.split("@", 1)[0]
+    # A ':' is a tag only if it's after the last '/': registries can carry a port.
+    slash = ref.rfind("/")
+    colon = ref.rfind(":")
+    if colon > slash:
+        ref = ref[:colon]
+    return ref
+
+
+def image_files() -> tuple[list[Path], list[Path]]:
+    """All Dockerfiles and Compose files in the repo, hidden/vendored dirs pruned."""
+    dockerfiles: list[Path] = []
+    composes: list[Path] = []
+    for root, dirs, files in os.walk(REPO):
+        dirs[:] = [d for d in dirs if not d.startswith(".") and d not in SKIP_DIRS]
+        for f in files:
+            low = f.lower()
+            if low.startswith("dockerfile"):
+                dockerfiles.append(Path(root) / f)
+            elif COMPOSE_FILE_RE.fullmatch(low):
+                composes.append(Path(root) / f)
+    return sorted(dockerfiles), sorted(composes)
+
+
+def referenced_images() -> dict[str, list[tuple[str, str]]]:
+    """Map bare image name -> list of (full ref as written, 'path:line').
+
+    Dockerfiles: resolves ARG-default FROMs, skips build-stage aliases
+    (FROM <stage>). Compose files: reads `image:` keys, resolving
+    ${VAR:-default} interpolation. References that still contain an
+    unresolvable variable are skipped in both.
+    """
+    refs: dict[str, list[tuple[str, str]]] = {}
+
+    def add(image: str, path: Path, n: int) -> None:
+        refs.setdefault(bare_name(image), []).append((image, f"{path.relative_to(REPO)}:{n}"))
+
+    dockerfiles, composes = image_files()
+    for path in dockerfiles:
+        args: dict[str, str] = {}
+        stages: set[str] = set()
+        for n, line in enumerate(path.read_text().splitlines(), 1):
+            if m := ARG_RE.match(line):
+                args[m.group(1)] = m.group(2)
+            if m := FROM_RE.match(line):
+                image = m.group(1)
+                # Resolve ${VAR} against ARG defaults seen so far.
+                image = VAR_RE.sub(lambda mm: args.get(mm.group(1), mm.group(0)), image)
+                # Track `AS <stage>` and skip references to prior stages.
+                after = line[m.end() :].strip().split()
+                if len(after) >= 2 and after[0].lower() == "as":
+                    stages.add(after[1].lower())
+                if image.lower() in stages or "$" in image:
+                    continue
+                add(image, path, n)
+    for path in composes:
+        for n, line in enumerate(path.read_text().splitlines(), 1):
+            if m := IMAGE_KEY_RE.match(line):
+                image = COMPOSE_VAR_RE.sub(
+                    lambda mm: mm.group(0) if mm.group(2) is None else mm.group(2),
+                    m.group(1),
+                )
+                if "$" in image:
+                    continue
+                add(image, path, n)
+    return refs
+
+
+def trivy_image_license(ref: str) -> set[str]:
+    """Return the set of disallowed license names trivy finds inside an image.
+
+    `ref` is the reference as written (tag/digest included), so the scan tests
+    the artifact actually in use; untagged refs default to :latest.
+    """
+    target = ref if ref != bare_name(ref) else f"{ref}:latest"
+    cmd = [
+        "trivy",
+        "image",
+        "--config",
+        str(REPO / ".trivyaml"),
+        "--scanners",
+        "license",
+        "--severity",
+        "CRITICAL",
+        "--format",
+        "json",
+        "--quiet",
+        target,
+    ]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=600)
+    except (OSError, subprocess.TimeoutExpired) as e:
+        print(f"    (image scan skipped for {target}: {e})")
+        return set()
+    if out.returncode not in (0, 1) or not out.stdout.strip():
+        print(f"    (image scan inconclusive for {target})")
+        return set()
+    data = json.loads(out.stdout)
+    names = set()
+    for r in data.get("Results") or []:
+        for lic in r.get("Licenses") or []:
+            names.add(lic.get("Name", ""))
+    return {n for n in names if n}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--scan-images",
+        action="store_true",
+        help="also pull small images and check for license drift (needs trivy)",
+    )
+    args = ap.parse_args()
+
+    manifest = tomllib.loads(MANIFEST.read_text())
+    entries = {e["name"]: e for e in manifest.get("image", [])}
+    for name, e in entries.items():
+        if e.get("ships") not in ALLOWED_SHIPS:
+            print(
+                f"✖ manifest entry {name!r} has invalid ships={e.get('ships')!r} "
+                f"(expected one of {sorted(ALLOWED_SHIPS)})"
+            )
+            return 2
+
+    refs = referenced_images()
+    failures: list[str] = []
+
+    # 1. novelty + 2. ship-mode
+    for name, uses in sorted(refs.items()):
+        where = ", ".join(loc for _, loc in uses)
+        entry = entries.get(name)
+        if entry is None:
+            failures.append(
+                f"unlisted image {name!r} referenced at {where} — "
+                f"add it to {MANIFEST.relative_to(REPO)} with license + ships"
+            )
+            continue
+        verdict, label = classify(entry["license"])
+        if verdict == BLOCK and entry["ships"] == "redistributed":
+            failures.append(
+                f"{name!r} is {entry['license']} ({label}) but marked "
+                f"ships=redistributed at {where} — disallowed when shipped"
+            )
+
+    # 3. stale entries (warn only)
+    for name in sorted(entries.keys() - refs.keys()):
+        print(
+            f"⚠ manifest entry {name!r} is no longer referenced by any Dockerfile or Compose file"
+        )
+
+    # optional drift scan, at each tag actually referenced
+    if args.scan_images:
+        for name, entry in sorted(entries.items()):
+            if name not in refs or name in SCAN_SKIP:
+                continue
+            declared = entry["license"]
+            for ref in sorted({r for r, _ in refs[name]}):
+                print(f"→ scanning {ref} for license drift…")
+                found = trivy_image_license(ref)
+                # Only source-available / non-commercial licenses signal a
+                # relicense: strong-copyleft (GPL/LGPL) shows up as normal base-OS
+                # system packages (mere aggregation), so flagging it here would be
+                # all false positives.
+                drift = {
+                    n
+                    for n in found
+                    if n.upper() != declared.upper()
+                    and classify(n)[1] in ("source-available", "non-commercial")
+                }
+                if drift:
+                    failures.append(
+                        f"{ref!r} manifest says {declared} but image contains "
+                        f"restricted license(s) {sorted(drift)} — relicense drift"
+                    )
+
+    if failures:
+        print(f"\n✖ {len(failures)} bundled-image violation(s):")
+        for f in failures:
+            print(f"    {f}")
+        return 1
+    print(f"✓ all {len(refs)} referenced image(s) are reviewed and compatible.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_dep_licenses.py
+++ b/scripts/check_dep_licenses.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Gate packaged dependency licenses against the project's Apache-2.0 policy.
+
+One policy, many sources (issue #92). The unified default is `osv-scanner`, which
+reads both uv.lock and pnpm-lock.yaml in one pass and resolves licenses via
+deps.dev (neither lockfile embeds license data, so this enrichment is what makes a
+single tool possible). pip-licenses (Python) and `pnpm licenses list` (Node) are
+kept as offline alternates that read locally-installed metadata. Every source is
+reduced to a package -> license-string mapping and classified identically here.
+
+Usage:
+    # unified (both ecosystems, no install needed). osv exits non-zero when it
+    # finds anything outside its allowlist, so tolerate that and classify here:
+    osv-scanner scan source --format json \
+        --licenses="MIT,Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC" \
+        --lockfile uv.lock --lockfile pnpm-lock.yaml > osv.json || true
+    python3 scripts/check_dep_licenses.py --source osv < osv.json
+
+    # offline alternates
+    pip-licenses --format=json | python3 scripts/check_dep_licenses.py --source pip
+    pnpm --dir apps/web licenses list --json | python3 scripts/check_dep_licenses.py --source pnpm
+
+The osv allowlist only controls which packages osv *surfaces* (permissive ones are
+omitted); the real block/flag/allow decision is made by classify() below, so a
+narrow allowlist is safe — anything dangerous still surfaces and gets classified.
+
+Policy:
+    block  strong-copyleft (GPL/AGPL), source-available (Elastic/BUSL/SSPL),
+           non-commercial (CC-*-NC)             -> exit 1
+    flag   LGPL and UNKNOWN                      -> reported, does not block
+    allow  permissive, MPL-2.0, and anything on the exception allowlist
+
+`--report-only` never exits non-zero (used for the first rollout PR to surface
+the baseline before the gate goes blocking). Package-specific exceptions live in
+scripts/dep_license_exceptions.txt (one `name` or `name==reason` per line).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+EXCEPTIONS_FILE = Path(__file__).with_name("dep_license_exceptions.txt")
+
+# Ordered most-specific-first: AGPL/LGPL must be tested before GPL, since both
+# strings contain "GPL". Each entry: (verdict, human label, regex over the
+# uppercased license string).
+BLOCK, FLAG, ALLOW = "BLOCK", "FLAG", "ALLOW"
+RULES: list[tuple[str, str, re.Pattern[str]]] = [
+    # --- source-available (block): not OSI/Apache-compatible when shipped ---
+    (BLOCK, "source-available", re.compile(r"ELASTIC|\bELV2\b")),
+    (BLOCK, "source-available", re.compile(r"BUSL|BUSINESS SOURCE")),
+    (BLOCK, "source-available", re.compile(r"\bSSPL\b|SERVER SIDE PUBLIC")),
+    (BLOCK, "source-available", re.compile(r"COMMONS CLAUSE")),
+    # --- non-commercial Creative Commons (block) ---
+    (BLOCK, "non-commercial", re.compile(r"\bNC\b|NONCOMMERCIAL|NON-COMMERCIAL")),
+    # --- weak copyleft (flag, not block): LGPL before GPL ---
+    (FLAG, "weak-copyleft", re.compile(r"\bA?LGPL|LESSER GENERAL PUBLIC")),
+    # --- strong copyleft (block): AGPL before GPL ---
+    (BLOCK, "strong-copyleft", re.compile(r"\bAGPL|AFFERO")),
+    (BLOCK, "strong-copyleft", re.compile(r"\bGPL|GENERAL PUBLIC")),
+    # --- permissive / notice / weak-file-copyleft treated as allowed ---
+    (
+        ALLOW,
+        "permissive",
+        re.compile(
+            r"\bMIT\b|\bBSD\b|APACHE|\bISC\b|PYTHON SOFTWARE|\bPSF\b|MPL|MOZILLA|"
+            r"\bZLIB\b|UNLICENSE|\b0BSD\b|\bWTFPL\b|BOOST|\bBSL-1\b|\bCC0\b|"
+            r"OFL|OPEN FONT|\bEPL\b|ECLIPSE PUBLIC|\bMIT-0\b|POSTGRESQL"
+        ),
+    ),
+]
+
+
+def load_exceptions() -> set[str]:
+    if not EXCEPTIONS_FILE.exists():
+        return set()
+    out: set[str] = set()
+    for line in EXCEPTIONS_FILE.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        out.add(line.split("==", 1)[0].strip().lower())
+    return out
+
+
+def classify(license_str: str) -> tuple[str, str]:
+    """Return (verdict, label) for a raw license string."""
+    text = (license_str or "").upper()
+    if not text or text in {"UNKNOWN", "NONE", "UNLICENSED"}:
+        return FLAG, "unknown"
+    for verdict, label, pat in RULES:
+        if pat.search(text):
+            return verdict, label
+    return FLAG, "unrecognized"
+
+
+def parse_pip(raw: str) -> list[tuple[str, str]]:
+    return [(e.get("Name", "?"), e.get("License", "")) for e in json.loads(raw)]
+
+
+def parse_pnpm(raw: str) -> list[tuple[str, str]]:
+    """pnpm licenses list --json -> {licenseString: [{name, versions, ...}]}."""
+    data = json.loads(raw)
+    if isinstance(data, dict) and set(data) == {"error"}:
+        raise SystemExit(f"pnpm error: {data['error']}")
+    pkgs: list[tuple[str, str]] = []
+    for license_str, entries in (data or {}).items():
+        for entry in entries:
+            pkgs.append((entry.get("name", "?"), license_str))
+    return pkgs
+
+
+def parse_osv(raw: str) -> list[tuple[str, str]]:
+    """osv-scanner --format json -> results[].packages[] with a `licenses` list.
+
+    Only packages outside osv's allowlist are present; each carries the SPDX id(s)
+    deps.dev resolved (or "UNKNOWN"). Multiple ids are joined so classify() sees
+    the whole expression (e.g. "Apache-2.0 OR MIT").
+    """
+    data = json.loads(raw)
+    pkgs: list[tuple[str, str]] = []
+    for result in data.get("results", []):
+        for pkg in result.get("packages", []):
+            name = pkg.get("package", {}).get("name", "?")
+            licenses = pkg.get("licenses", []) or []
+            pkgs.append((name, " ".join(licenses)))
+    return pkgs
+
+
+PARSERS = {"pip": parse_pip, "pnpm": parse_pnpm, "osv": parse_osv}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--source", choices=tuple(PARSERS), required=True)
+    ap.add_argument(
+        "--report-only", action="store_true", help="print findings but always exit 0 (rollout mode)"
+    )
+    args = ap.parse_args()
+
+    raw = sys.stdin.read()
+    if not raw.strip():
+        print(f"error: no input on stdin for --source {args.source}", file=sys.stderr)
+        return 2
+    packages = PARSERS[args.source](raw)
+
+    exceptions = load_exceptions()
+    blocked: list[tuple[str, str, str]] = []
+    flagged: list[tuple[str, str, str]] = []
+    for name, license_str in sorted(set(packages)):
+        if name.lower() in exceptions:
+            continue
+        verdict, label = classify(license_str)
+        if verdict == BLOCK:
+            blocked.append((name, license_str, label))
+        elif verdict == FLAG:
+            flagged.append((name, license_str, label))
+
+    if flagged:
+        print(f"⚠ {len(flagged)} package(s) to review ({args.source}):")
+        for name, lic, label in flagged:
+            print(f"    {label:16} {name} — {lic!r}")
+    if blocked:
+        print(f"✖ {len(blocked)} DISALLOWED license(s) ({args.source}):")
+        for name, lic, label in blocked:
+            print(f"    {label:16} {name} — {lic!r}")
+    else:
+        print(f"✓ no disallowed dependency licenses ({args.source}).")
+
+    if blocked and not args.report_only:
+        print(
+            "\nBlock a package only after review: add it to "
+            f"{EXCEPTIONS_FILE.name} with a reason, or remove the dependency."
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dep_license_exceptions.txt
+++ b/scripts/dep_license_exceptions.txt
@@ -1,0 +1,11 @@
+# Reviewed dependency-license exceptions for scripts/check_dep_licenses.py.
+#
+# One package per line, either `name` or `name==reason`. A listed package is
+# skipped by the gate. Only add a package after a human has confirmed its real
+# license is compatible (e.g. metadata was ambiguous, or a flagged classification
+# is a false positive). Keep a reason so the next reader knows why.
+#
+# Example:
+#   some-pkg==dual-licensed MIT OR GPL; we use it under MIT
+
+parsehawk==our own package (Apache-2.0); shows as UNKNOWN in deps.dev


### PR DESCRIPTION
Implements the two-tier license compliance plan from #92 (see the [revised plan comment](https://github.com/parsehawk/parsehawk/issues/92#issuecomment-4913855625)). Closes #92.

## What

ParseHawk ships under Apache-2.0, but nothing verified that its dependencies or the container images it references are compatible. This adds two in-repo guards sharing one policy:

- **Tier 1 — dependency licenses** (`scripts/check_dep_licenses.py`): osv-scanner reads `uv.lock` + `pnpm-lock.yaml` in one pass (licenses resolved via deps.dev; neither lockfile embeds license data) and one classifier applies the tiered policy — **block** GPL/AGPL, source-available (ELv2/BUSL/SSPL), non-commercial; **flag** LGPL/unknown; **allow** permissive + MPL-2.0. Reviewed exceptions live in `scripts/dep_license_exceptions.txt`.
- **Tier 2 — bundled/referenced images** (`scripts/check_bundled_images.py` + `licenses/bundled-images.toml`): extracts every image reference in the repo — Dockerfile `FROM`s (ARG defaults resolved) **and Compose `image:` keys** (`${VAR:-default}` interpolation) — and enforces a reviewed manifest recording each image's license and how it ships. Verdict = license × ship-mode: Phoenix (ELv2) is fine as `runtime-pull`, disallowed as `redistributed`. Unlisted images fail, so a human classifies every new image before merge. `--scan-images` adds a trivy drift scan at the tag actually referenced (catches vendor relicensing).

Wiring: `just licenses*` recipes (folded into `just check`), two pre-commit hooks, and a path-gated CI job. `THIRD_PARTY_NOTICES.md` is extended with the redistribution boundary (only the GHCR API/worker image is published; base-OS packages ship as mere aggregation) and the previously undocumented NuExtract3 model weights.

## Why this shape

The motivating case is Arize Phoenix (ELv2), which enters via `services/phoenix/Dockerfile.phoenix` and never appears in any lockfile — invisible to every dependency scanner, FOSSA included. Details, alternatives considered, and empirical tool findings are in the plan comment on #92.

An Apache `NOTICE` file was considered and deliberately not added: Apache-2.0 doesn't require one, its §4(d) propagation mechanism only matters once the file actually ships inside published artifacts, and main's `THIRD_PARTY_NOTICES.md` already carries the human-readable inventory — extending it avoids a second overlapping document that would drift. A minimal NOTICE attribution stub can be added later if it is also COPY'd into the published image.

## Reviewer notes

- **CI dependency gate starts `--report-only`** — flip to blocking (drop the flag in `ci-checks.yaml`) after the first green run. The image guard blocks from day one.
- **Local dev**: `just licenses-deps` skips with a warning when osv-scanner isn't installed, so `just check`/pre-commit stay green offline; CI installs osv-scanner and is the blocking authority.
- **Conservative classification**: the manifest marks `nginx` as `redistributed` even though `publish-image.yaml` intentionally publishes only the API/worker image — stricter than reality, which fails safe. Downgrade to `build-only`/`runtime-pull` if you prefer exactness.
- **Known limitation** (documented in the script): a Compose service that both `build:`s and names an `image:` would surface as novel; none exists today, and "novel" fails safe.

## Verification

All modes exercised live on macOS: guard passes clean on the real tree (5 images, compose ref included); novelty fails for unlisted images via Dockerfile `FROM`, Compose `image:`, and an out-of-tree Dockerfile; ship-mode fails when Phoenix is flipped to `redistributed`; drift scan detects `Elastic-2.0` inside `arizephoenix/phoenix:17.20.0` when the manifest mis-declares it as Apache-2.0. Real osv run: 78 Python + 585 Node packages, 4 flagged for review, none blocked. No runtime/serving/compose behavior changes, so `parsehawk restart` + `just e2e` was not run; Linux/NVIDIA was not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
