### PR TITLE
feat(extractors): per-extractor reasoning effort control

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -134,7 +134,7 @@ describe("App run workflow", () => {
     expect(maxActiveUploads).toBeLessThanOrEqual(3);
   });
 
-  it("saves the extractor thinking setting", async () => {
+  it("saves the extractor reasoning effort setting", async () => {
     let createPayload: Record<string, unknown> | null = null;
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
       const url = String(input);
@@ -148,7 +148,7 @@ describe("App run workflow", () => {
           name: "invoice",
           display_name: "Invoice",
           instructions: "Extract invoice fields.",
-          enable_thinking: true,
+          reasoning_effort: "high",
           schema: createPayload?.schema,
           examples: [],
           created_at: "2026-06-21T00:00:00Z",
@@ -166,13 +166,52 @@ describe("App run workflow", () => {
     await userEvent.click(await screen.findByRole("button", { name: "New" }));
     await userEvent.type(screen.getByLabelText("Display name"), "Invoice");
     await userEvent.type(screen.getByLabelText("Instructions"), "Extract invoice fields.");
-    await userEvent.click(screen.getByRole("checkbox", { name: "Enable thinking" }));
+    await userEvent.selectOptions(screen.getByLabelText("Reasoning effort"), "high");
     await userEvent.click(screen.getByRole("button", { name: "Create extractor" }));
 
     await waitFor(() => {
-      expect(createPayload?.enable_thinking).toBe(true);
+      expect(createPayload?.reasoning_effort).toBe("high");
     });
     expect(createPayload).not.toHaveProperty("name");
+  });
+
+  it("sends a null reasoning effort for the model default", async () => {
+    let createPayload: Record<string, unknown> | null = null;
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input, init) => {
+      const url = String(input);
+      if (url === "/v1/files") {
+        return jsonResponse([]);
+      }
+      if (url === "/v1/extractors" && init?.method === "POST") {
+        createPayload = JSON.parse(String(init.body));
+        return jsonResponse({
+          id: "extractor_123",
+          name: "invoice",
+          display_name: "Invoice",
+          instructions: "Extract invoice fields.",
+          reasoning_effort: null,
+          schema: createPayload?.schema,
+          examples: [],
+          created_at: "2026-06-21T00:00:00Z",
+          updated_at: "2026-06-21T00:00:00Z"
+        });
+      }
+      if (url === "/v1/extractors") {
+        return jsonResponse([]);
+      }
+      return jsonResponse({ detail: "unexpected request" }, { status: 500 });
+    });
+
+    render(<App />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "New" }));
+    await userEvent.type(screen.getByLabelText("Display name"), "Invoice");
+    await userEvent.type(screen.getByLabelText("Instructions"), "Extract invoice fields.");
+    await userEvent.click(screen.getByRole("button", { name: "Create extractor" }));
+
+    await waitFor(() => {
+      expect(createPayload?.reasoning_effort).toBeNull();
+    });
   });
 
   it("sends a manually edited extractor name on create", async () => {
@@ -189,7 +228,7 @@ describe("App run workflow", () => {
           name: String(createPayload?.name),
           display_name: "Invoice",
           instructions: "Extract invoice fields.",
-          enable_thinking: false,
+          reasoning_effort: null,
           schema: createPayload?.schema,
           examples: [],
           created_at: "2026-06-21T00:00:00Z",
@@ -230,7 +269,7 @@ describe("App run workflow", () => {
           name: "very-long-generated-name",
           display_name: createPayload?.display_name,
           instructions: "Extract invoice fields.",
-          enable_thinking: false,
+          reasoning_effort: null,
           schema: createPayload?.schema,
           examples: [],
           created_at: "2026-06-21T00:00:00Z",
@@ -272,7 +311,7 @@ describe("App run workflow", () => {
           name: "invoice",
           display_name: "Invoice",
           instructions: "Extract invoice fields.",
-          enable_thinking: false,
+          reasoning_effort: null,
           schema: createPayload?.schema,
           examples: [],
           created_at: "2026-06-21T00:00:00Z",
@@ -633,7 +672,7 @@ describe("App run workflow", () => {
           name: "invoice",
           display_name: "Invoice",
           instructions: "Extract invoice fields.",
-          enable_thinking: false,
+          reasoning_effort: null,
           provider_name: createPayload?.provider_name,
           model: createPayload?.model,
           schema: createPayload?.schema,
@@ -680,7 +719,7 @@ describe("App run workflow", () => {
           name: "invoice",
           display_name: "Invoice",
           instructions: "Extract invoice fields.",
-          enable_thinking: false,
+          reasoning_effort: null,
           provider_name: "openai_compatible_api",
           model: null,
           schema: createPayload?.schema,
@@ -727,7 +766,7 @@ describe("App run workflow", () => {
           name: "invoice",
           display_name: "Invoice",
           instructions: "Extract invoice fields.",
-          enable_thinking: false,
+          reasoning_effort: null,
           provider_name: createPayload.provider_name,
           model: "server-model",
           schema: createPayload.schema,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -106,6 +106,7 @@ import type {
   JobStatus,
   Provider,
   ProviderName,
+  ReasoningEffort,
   SchemaValidation,
   SchemaValidationRequest
 } from "./types";
@@ -126,6 +127,16 @@ const PROVIDERS: { name: ProviderName; label: string }[] = [
   { name: "microsoft_foundry", label: "Microsoft Foundry" }
 ];
 const DEFAULT_PROVIDER_NAME: ProviderName = "openai_compatible_api";
+// "" is the UI spelling for null: use the model's own default reasoning.
+const REASONING_EFFORT_OPTIONS: { value: ReasoningEffort | ""; label: string }[] = [
+  { value: "", label: "Model default" },
+  { value: "none", label: "None" },
+  { value: "minimal", label: "Minimal" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+  { value: "xhigh", label: "Extra high" }
+];
 const FOUNDRY_BASE_URL_PLACEHOLDER = "https://your-resource-name.services.ai.azure.com/openai/v1";
 const FOUNDRY_PROJECT_URL_PLACEHOLDER =
   "https://your-resource-name.services.ai.azure.com/api/projects/your-project-name";
@@ -172,7 +183,7 @@ export default function App() {
   const [nameManuallyEdited, setNameManuallyEdited] = useState(false);
   const [displayName, setDisplayName] = useState(emptyDisplayName);
   const [instructions, setInstructions] = useState(emptyInstructions);
-  const [enableThinking, setEnableThinking] = useState(false);
+  const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort | "">("");
   const [providerName, setProviderName] = useState<ProviderName>(DEFAULT_PROVIDER_NAME);
   const [model, setModel] = useState("");
   const [providerModels, setProviderModels] = useState<string[]>([]);
@@ -183,7 +194,7 @@ export default function App() {
       name: emptyExtractorName,
       displayName: emptyDisplayName,
       instructions: emptyInstructions,
-      enableThinking: false,
+      reasoningEffort: "",
       providerName: DEFAULT_PROVIDER_NAME,
       model: "",
       schemaText: prettyJson(fieldSchemaFromFields([])),
@@ -232,7 +243,7 @@ export default function App() {
     name,
     displayName,
     instructions,
-    enableThinking,
+    reasoningEffort,
     providerName,
     model,
     schemaText: schemaDraftText,
@@ -564,7 +575,7 @@ export default function App() {
     const base = {
       display_name: displayName,
       instructions,
-      enable_thinking: enableThinking,
+      reasoning_effort: reasoningEffort || null,
       provider_name: providerName,
       model: trimmedModel || null,
       examples: examplesToPayload(examples)
@@ -620,7 +631,7 @@ export default function App() {
     setNameManuallyEdited(false);
     setDisplayName(extractorLabel(extractor));
     setInstructions(extractor.instructions);
-    setEnableThinking(extractor.enable_thinking ?? false);
+    setReasoningEffort(extractor.reasoning_effort ?? "");
     setProviderName(extractor.provider_name ?? DEFAULT_PROVIDER_NAME);
     setModel(extractor.model ?? "");
     applyExtractorArtifacts(extractor);
@@ -639,7 +650,7 @@ export default function App() {
     setNameManuallyEdited(false);
     setDisplayName(emptyDisplayName);
     setInstructions(emptyInstructions);
-    setEnableThinking(false);
+    setReasoningEffort("");
     setProviderName(DEFAULT_PROVIDER_NAME);
     setModel("");
     setExamples(nextExamples);
@@ -652,7 +663,7 @@ export default function App() {
         name: emptyExtractorName,
         displayName: emptyDisplayName,
         instructions: emptyInstructions,
-        enableThinking: false,
+        reasoningEffort: "",
         providerName: DEFAULT_PROVIDER_NAME,
         model: "",
         schemaText: prettyJson(fieldSchemaFromFields(nextSchemaFields)),
@@ -686,7 +697,7 @@ export default function App() {
         name: extractor.name,
         displayName: extractorLabel(extractor),
         instructions: extractor.instructions,
-        enableThinking: extractor.enable_thinking ?? false,
+        reasoningEffort: extractor.reasoning_effort ?? "",
         providerName: extractor.provider_name ?? DEFAULT_PROVIDER_NAME,
         model: extractor.model ?? "",
         schemaText: prettyJson(fieldSchemaFromFields(nextFields)),
@@ -965,13 +976,30 @@ export default function App() {
                         {providerModelDescription(providerName, providerModelsError)}
                       </FieldDescription>
                     </Field>
-                    <CheckboxField
-                      id="extractor-enable-thinking"
-                      label="Enable thinking"
-                      checked={enableThinking}
-                      disabled={draftExtractorIsPrebuilt}
-                      onChange={setEnableThinking}
-                    />
+                    <Field>
+                      <FieldLabel htmlFor="extractor-reasoning-effort">
+                        Reasoning effort
+                      </FieldLabel>
+                      <NativeSelect
+                        id="extractor-reasoning-effort"
+                        value={reasoningEffort}
+                        disabled={draftExtractorIsPrebuilt}
+                        onChange={(event) =>
+                          setReasoningEffort(event.target.value as ReasoningEffort | "")
+                        }
+                      >
+                        {REASONING_EFFORT_OPTIONS.map((option) => (
+                          <NativeSelectOption key={option.value} value={option.value}>
+                            {option.label}
+                          </NativeSelectOption>
+                        ))}
+                      </NativeSelect>
+                      <FieldDescription>
+                        How much the model reasons before answering. Model default sends no
+                        reasoning parameter; models that do not support the selected level fail
+                        at extraction time with the provider&apos;s error.
+                      </FieldDescription>
+                    </Field>
                   </FieldGroup>
 
                   <Separator />
@@ -2785,7 +2813,7 @@ function extractorDraftSnapshot(props: {
   name: string;
   displayName: string;
   instructions: string;
-  enableThinking: boolean;
+  reasoningEffort: ReasoningEffort | "";
   providerName: ProviderName;
   model: string;
   schemaText: string;
@@ -2795,7 +2823,7 @@ function extractorDraftSnapshot(props: {
     name: props.name,
     displayName: props.displayName,
     instructions: props.instructions,
-    enableThinking: props.enableThinking,
+    reasoningEffort: props.reasoningEffort,
     providerName: props.providerName,
     model: props.model,
     schemaText: props.schemaText,

--- a/apps/web/src/api.ts
+++ b/apps/web/src/api.ts
@@ -6,6 +6,7 @@ import type {
   Provider,
   ProviderConfiguration,
   ProviderName,
+  ReasoningEffort,
   SchemaValidation,
   SchemaValidationRequest
 } from "./types";
@@ -84,7 +85,7 @@ export function createExtractor(payload: {
   name?: string;
   display_name: string;
   instructions: string;
-  enable_thinking: boolean;
+  reasoning_effort: ReasoningEffort | null;
   provider_name?: ProviderName;
   model?: string | null;
   schema: Record<string, unknown>;
@@ -102,7 +103,7 @@ export function updateExtractor(
   payload: {
     display_name: string;
     instructions: string;
-    enable_thinking: boolean;
+    reasoning_effort: ReasoningEffort | null;
     provider_name?: ProviderName;
     model?: string | null;
     schema?: Record<string, unknown>;

--- a/apps/web/src/examples.test.ts
+++ b/apps/web/src/examples.test.ts
@@ -40,7 +40,7 @@ describe("examples", () => {
       name: "invoice",
       display_name: "Invoice",
       instructions: "extract",
-      enable_thinking: false,
+      reasoning_effort: null,
       provider_name: "openai_compatible_api",
       model: null,
       schema: { type: "object" },

--- a/apps/web/src/types.ts
+++ b/apps/web/src/types.ts
@@ -11,6 +11,10 @@ export type FileRecord = {
 
 export type ProviderName = "openai" | "microsoft_foundry" | "openai_compatible_api";
 
+// Mirrors OpenAI's reasoning_effort values; null means "use the model's own
+// default" (no reasoning parameter is sent at all).
+export type ReasoningEffort = "none" | "minimal" | "low" | "medium" | "high" | "xhigh";
+
 export type ProviderConfiguration = {
   project_url?: string | null;
 };
@@ -29,7 +33,7 @@ export type Extractor = {
   name: string;
   display_name: string;
   instructions: string;
-  enable_thinking: boolean;
+  reasoning_effort: ReasoningEffort | null;
   provider_name: ProviderName | null;
   model: string | null;
   schema: Record<string, unknown>;

--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -27,7 +27,7 @@ from parsehawk.config import (
     Settings,
     default_inference_engine,
 )
-from parsehawk.core.domain.models import ProviderName
+from parsehawk.core.domain.models import ProviderName, ReasoningEffort
 from parsehawk.model_profiles import (
     RuntimePlatform,
     RuntimeProfileDefaults,
@@ -41,6 +41,12 @@ from parsehawk.server.runtime.vllm_env import (
 
 UNSUPPORTED_RUNTIME = "unsupported"
 _PROVIDER_NAMES = tuple(name.value for name in ProviderName)
+# "default" clears the effort back to null, i.e. the model's own default.
+_REASONING_EFFORT_CHOICES = ("default", *(effort.value for effort in ReasoningEffort))
+
+
+def _reasoning_effort_payload_value(argument: str) -> str | None:
+    return None if argument == "default" else argument
 
 
 def _default_runtime() -> str:
@@ -369,7 +375,7 @@ def build_parser() -> argparse.ArgumentParser:
     extract_parser.add_argument("--schema")
     extract_parser.add_argument("--instructions")
     extract_parser.add_argument("--name")
-    extract_parser.add_argument("--enable-thinking", action="store_true")
+    extract_parser.add_argument("--reasoning-effort", choices=_REASONING_EFFORT_CHOICES)
     extract_input = extract_parser.add_mutually_exclusive_group()
     extract_input.add_argument("--file-id")
     extract_input.add_argument("--text")
@@ -416,7 +422,7 @@ def build_parser() -> argparse.ArgumentParser:
     extractors_create_parser.add_argument("--instructions", required=True)
     extractors_create_parser.add_argument("--schema", required=True)
     extractors_create_parser.add_argument("--examples")
-    extractors_create_parser.add_argument("--enable-thinking", action="store_true")
+    extractors_create_parser.add_argument("--reasoning-effort", choices=_REASONING_EFFORT_CHOICES)
     extractors_create_parser.add_argument(
         "--provider", dest="provider_name", choices=_PROVIDER_NAMES
     )
@@ -429,7 +435,7 @@ def build_parser() -> argparse.ArgumentParser:
     extractors_put_parser.add_argument("--instructions", required=True)
     extractors_put_parser.add_argument("--schema", required=True)
     extractors_put_parser.add_argument("--examples")
-    extractors_put_parser.add_argument("--enable-thinking", action="store_true")
+    extractors_put_parser.add_argument("--reasoning-effort", choices=_REASONING_EFFORT_CHOICES)
     extractors_put_parser.add_argument("--provider", dest="provider_name", choices=_PROVIDER_NAMES)
     extractors_put_parser.add_argument("--model")
     _add_api_url(extractors_put_parser)
@@ -443,11 +449,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--provider", dest="provider_name", choices=_PROVIDER_NAMES
     )
     extractors_update_parser.add_argument("--model")
-    extractors_update_parser.add_argument(
-        "--enable-thinking",
-        action=argparse.BooleanOptionalAction,
-        default=None,
-    )
+    extractors_update_parser.add_argument("--reasoning-effort", choices=_REASONING_EFFORT_CHOICES)
     _add_api_url(extractors_update_parser)
     extractors_delete_parser = extractors_subparsers.add_parser("delete")
     extractors_delete_parser.add_argument("extractor_ref")
@@ -1058,10 +1060,11 @@ def extractors(args: argparse.Namespace) -> None:
         payload = {
             "display_name": display_name,
             "instructions": read_text_argument(args.instructions),
-            "enable_thinking": args.enable_thinking,
             "schema": read_json_file(args.schema),
             "examples": read_json_file(args.examples) if args.examples else [],
         }
+        if args.reasoning_effort is not None:
+            payload["reasoning_effort"] = _reasoning_effort_payload_value(args.reasoning_effort)
         if args.name is not None:
             payload["name"] = args.name
         if args.provider_name is not None:
@@ -1073,10 +1076,11 @@ def extractors(args: argparse.Namespace) -> None:
         payload = {
             "display_name": args.display_name,
             "instructions": read_text_argument(args.instructions),
-            "enable_thinking": args.enable_thinking,
             "schema": read_json_file(args.schema),
             "examples": read_json_file(args.examples) if args.examples else [],
         }
+        if args.reasoning_effort is not None:
+            payload["reasoning_effort"] = _reasoning_effort_payload_value(args.reasoning_effort)
         if args.name is not None:
             payload["name"] = args.name
         if args.provider_name is not None:
@@ -1097,8 +1101,8 @@ def extractors(args: argparse.Namespace) -> None:
             payload["display_name"] = args.display_name
         if args.instructions is not None:
             payload["instructions"] = read_text_argument(args.instructions)
-        if args.enable_thinking is not None:
-            payload["enable_thinking"] = args.enable_thinking
+        if args.reasoning_effort is not None:
+            payload["reasoning_effort"] = _reasoning_effort_payload_value(args.reasoning_effort)
         if args.provider_name is not None:
             payload["provider_name"] = args.provider_name
         if args.model is not None:
@@ -1874,10 +1878,11 @@ def create_ad_hoc_extractor(args: argparse.Namespace) -> str:
     payload = {
         "display_name": args.name or default_extractor_name(args),
         "instructions": read_text_argument(args.instructions),
-        "enable_thinking": args.enable_thinking,
         "schema": read_json_file(args.schema),
         "examples": [],
     }
+    if args.reasoning_effort is not None:
+        payload["reasoning_effort"] = _reasoning_effort_payload_value(args.reasoning_effort)
     extractor = api_request(args.api_url, "POST", "/v1/extractors", payload=payload)
     return str(extractor["id"])
 

--- a/src/parsehawk/core/application/ports.py
+++ b/src/parsehawk/core/application/ports.py
@@ -116,7 +116,7 @@ class ExtractionRequest:
         source_content_type: str | None = None,
         source_images: list[PreparedImage] | None = None,
         instructions: str,
-        enable_thinking: bool,
+        reasoning_effort: str | None = None,
         schema: dict,
         examples: list[dict],
     ) -> None:
@@ -125,7 +125,7 @@ class ExtractionRequest:
         self.source_content_type = source_content_type
         self.source_images = source_images or []
         self.instructions = instructions
-        self.enable_thinking = enable_thinking
+        self.reasoning_effort = reasoning_effort
         self.schema = schema
         self.examples = examples
 

--- a/src/parsehawk/core/application/services.py
+++ b/src/parsehawk/core/application/services.py
@@ -33,6 +33,7 @@ from parsehawk.core.domain.models import (
     JobStatus,
     Provider,
     ProviderName,
+    ReasoningEffort,
     ValidationIssue,
     extractor_name_suffix,
     normalize_provider_configuration,
@@ -49,11 +50,14 @@ SUPPORTED_FILE_SUFFIXES = {".pdf", ".jpg", ".jpeg", ".png", ".txt", ".md", ".mar
 DEFAULT_PROVIDER_NAME = ProviderName.OPENAI_COMPATIBLE
 
 
-class _ModelNotProvided:
+# Sentinel distinguishing "field absent from the update" from an explicit None,
+# which is a meaningful value for nullable extractor fields (model inherits the
+# runtime default; reasoning_effort uses the model's own default).
+class _NotProvided:
     pass
 
 
-MODEL_NOT_PROVIDED = _ModelNotProvided()
+NOT_PROVIDED = _NotProvided()
 
 
 class DeleteJobResult(StrEnum):
@@ -137,7 +141,7 @@ class ExtractorService:
         display_name: str | None = None,
         name: str | None = None,
         instructions: str,
-        enable_thinking: bool = False,
+        reasoning_effort: ReasoningEffort | None = None,
         provider_name: ProviderName | None = None,
         model: str | None = None,
         schema: dict[str, Any] | None = None,
@@ -163,7 +167,7 @@ class ExtractorService:
             name=stable_name,
             display_name=display_name,
             instructions=instructions,
-            enable_thinking=enable_thinking,
+            reasoning_effort=reasoning_effort,
             provider_name=resolved_provider_name,
             model=resolved_model,
             schema=schema,
@@ -196,9 +200,9 @@ class ExtractorService:
         *,
         display_name: str | None = None,
         instructions: str | None = None,
-        enable_thinking: bool | None = None,
+        reasoning_effort: ReasoningEffort | None | _NotProvided = NOT_PROVIDED,
         provider_name: ProviderName | None = None,
-        model: str | None | _ModelNotProvided = MODEL_NOT_PROVIDED,
+        model: str | None | _NotProvided = NOT_PROVIDED,
         schema: dict[str, Any] | None = None,
         examples: List[dict[str, Any]] | None = None,
     ) -> Extractor:
@@ -210,12 +214,12 @@ class ExtractorService:
             updates["display_name"] = display_name
         if instructions is not None:
             updates["instructions"] = instructions
-        if enable_thinking is not None:
-            updates["enable_thinking"] = enable_thinking
+        if not isinstance(reasoning_effort, _NotProvided):
+            updates["reasoning_effort"] = reasoning_effort
         resolved_provider_name = provider_name or current.provider_name or self._default_provider
         if provider_name is not None:
             updates["provider_name"] = provider_name
-        if not isinstance(model, _ModelNotProvided):
+        if not isinstance(model, _NotProvided):
             updates["model"] = self._normalize_model(resolved_provider_name, model)
         elif provider_name is not None:
             self._normalize_model(resolved_provider_name, current.model)
@@ -234,7 +238,7 @@ class ExtractorService:
         display_name: str,
         body_name: str | None = None,
         instructions: str,
-        enable_thinking: bool = False,
+        reasoning_effort: ReasoningEffort | None = None,
         provider_name: ProviderName | None = None,
         model: str | None = None,
         schema: dict[str, Any] | None = None,
@@ -249,7 +253,7 @@ class ExtractorService:
                 existing,
                 display_name=display_name,
                 instructions=instructions,
-                enable_thinking=enable_thinking,
+                reasoning_effort=reasoning_effort,
                 provider_name=provider_name,
                 model=model,
                 schema=schema,
@@ -262,7 +266,7 @@ class ExtractorService:
             name=extractor_ref,
             display_name=display_name,
             instructions=instructions,
-            enable_thinking=enable_thinking,
+            reasoning_effort=reasoning_effort,
             provider_name=provider_name,
             model=model,
             schema=schema,
@@ -280,7 +284,7 @@ class ExtractorService:
         *,
         display_name: str,
         instructions: str,
-        enable_thinking: bool,
+        reasoning_effort: ReasoningEffort | None,
         provider_name: ProviderName | None,
         model: str | None,
         schema: dict[str, Any] | None,
@@ -293,7 +297,7 @@ class ExtractorService:
             update={
                 "display_name": display_name,
                 "instructions": instructions,
-                "enable_thinking": enable_thinking,
+                "reasoning_effort": reasoning_effort,
                 "provider_name": resolved_provider_name,
                 "model": resolved_model,
                 "schema_": self._validate_schema(schema),
@@ -596,7 +600,7 @@ class JobService:
                     source_content_type=source.content_type,
                     source_images=source.images,
                     instructions=extractor.instructions,
-                    enable_thinking=extractor.enable_thinking,
+                    reasoning_effort=extractor.reasoning_effort,
                     schema=extractor.schema,
                     examples=self._resolve_examples(extractor),
                 ),

--- a/src/parsehawk/core/domain/models.py
+++ b/src/parsehawk/core/domain/models.py
@@ -72,6 +72,24 @@ def normalize_provider_configuration(
     return {}
 
 
+class ReasoningEffort(StrEnum):
+    """Explicit reasoning effort for an extractor's model.
+
+    The values mirror OpenAI's ``reasoning_effort`` parameter. Extractors store
+    ``None`` by default, which means "send no reasoning parameter and use the
+    model's own default" — the only setting that is safe for every model.
+    Which explicit values a model accepts is the provider's call; incompatible
+    pairs surface the provider's error at extraction time.
+    """
+
+    NONE = "none"
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    XHIGH = "xhigh"
+
+
 # NuExtract3 is fine-tuned on its own chat template, so only these exact models
 # use the NuExtract payload adapter; every other model uses the generic adapter.
 # Hardcoded from https://huggingface.co/collections/numind/nuextract3 and
@@ -152,7 +170,7 @@ class Extractor(Entity):
     name: str
     display_name: str = ""
     instructions: str
-    enable_thinking: bool = False
+    reasoning_effort: ReasoningEffort | None = None
     provider_name: ProviderName | None = None
     model: str | None = None
     schema_: dict[str, Any] = Field(alias="schema")

--- a/src/parsehawk/server/adapters/persistence/migrations/20260709090000_extractor_reasoning_effort.sql
+++ b/src/parsehawk/server/adapters/persistence/migrations/20260709090000_extractor_reasoning_effort.sql
@@ -1,0 +1,38 @@
+-- Replace the boolean enable_thinking with a nullable reasoning effort
+-- (none | minimal | low | medium | high | xhigh). NULL means "send no
+-- reasoning parameter and use the model's own default", which is the only
+-- setting that is safe for every model.
+--
+-- The backfill must preserve behavior per payload adapter:
+--   * enable_thinking=0 sent nothing anywhere -> NULL everywhere.
+--   * enable_thinking=1 only had a request effect for NuExtract3 models
+--     (thinking on via chat_template_kwargs) -> 'medium' keeps thinking on.
+--     A NULL model inherits the bundled NuExtract3 runtime, so it counts.
+--   * enable_thinking=1 on any other model sent nothing (the engine never set
+--     a reasoning mode) -> NULL, so e.g. gpt-4o extractors keep working
+--     instead of newly sending reasoning_effort and failing with HTTP 400.
+-- The NuExtract3 model list is snapshotted as of this migration on purpose.
+
+ALTER TABLE extractors ADD COLUMN reasoning_effort TEXT;
+
+UPDATE extractors
+SET reasoning_effort = 'medium'
+WHERE enable_thinking = 1
+  AND (
+    model IS NULL
+    OR model IN (
+      'numind/NuExtract3',
+      'numind/NuExtract3-GGUF',
+      'numind/NuExtract3-W8A8',
+      'numind/NuExtract3-W4A16',
+      'numind/NuExtract3-FP8',
+      'numind/NuExtract3-mlx-4bits',
+      'numind/NuExtract3-mlx-5bits',
+      'numind/NuExtract3-mlx-6bits',
+      'numind/NuExtract3-mlx-8bits',
+      'numind/NuExtract3-mlx-nvfp4',
+      'numind/NuExtract3-mlx-mxfp8'
+    )
+  );
+
+ALTER TABLE extractors DROP COLUMN enable_thinking;

--- a/src/parsehawk/server/adapters/persistence/sqlite.py
+++ b/src/parsehawk/server/adapters/persistence/sqlite.py
@@ -20,6 +20,7 @@ from parsehawk.core.domain.models import (
     JobStatus,
     Provider,
     ProviderName,
+    ReasoningEffort,
     utc_now,
 )
 from parsehawk.server.adapters.persistence.migrations import apply_pending
@@ -124,7 +125,7 @@ class SQLiteExtractorRow:
     name: str
     display_name: str
     instructions: str
-    enable_thinking: int
+    reasoning_effort: str | None
     provider_name: str | None
     model: str | None
     schema: str
@@ -142,7 +143,9 @@ class SQLiteExtractorRow:
             name=extractor.name,
             display_name=extractor.display_name,
             instructions=extractor.instructions,
-            enable_thinking=1 if extractor.enable_thinking else 0,
+            reasoning_effort=extractor.reasoning_effort.value
+            if extractor.reasoning_effort
+            else None,
             provider_name=extractor.provider_name.value if extractor.provider_name else None,
             model=extractor.model,
             schema=_dump_json(extractor.schema),
@@ -170,7 +173,9 @@ class SQLiteExtractorRow:
             name=self.name,
             display_name=self.display_name,
             instructions=self.instructions,
-            enable_thinking=bool(self.enable_thinking),
+            reasoning_effort=ReasoningEffort(self.reasoning_effort)
+            if self.reasoning_effort
+            else None,
             provider_name=ProviderName(self.provider_name) if self.provider_name else None,
             model=self.model,
             schema=_load_json(self.schema),
@@ -304,7 +309,7 @@ class SQLiteExtractorRepository:
             self._conn.execute(
                 """
                 INSERT INTO extractors (
-                    id, name, display_name, instructions, enable_thinking, provider_name, model,
+                    id, name, display_name, instructions, reasoning_effort, provider_name, model,
                     schema, examples, source, seed_key, seed_version, created_at, updated_at
                 )
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -312,7 +317,7 @@ class SQLiteExtractorRepository:
                     name = excluded.name,
                     display_name = excluded.display_name,
                     instructions = excluded.instructions,
-                    enable_thinking = excluded.enable_thinking,
+                    reasoning_effort = excluded.reasoning_effort,
                     provider_name = excluded.provider_name,
                     model = excluded.model,
                     schema = excluded.schema,
@@ -328,7 +333,7 @@ class SQLiteExtractorRepository:
                     row.name,
                     row.display_name,
                     row.instructions,
-                    row.enable_thinking,
+                    row.reasoning_effort,
                     row.provider_name,
                     row.model,
                     row.schema,

--- a/src/parsehawk/server/api/fastapi/app.py
+++ b/src/parsehawk/server/api/fastapi/app.py
@@ -9,7 +9,7 @@ from fastapi.responses import FileResponse as FastAPIFileResponse
 from fastapi.responses import JSONResponse
 
 from parsehawk import telemetry, tracing
-from parsehawk.core.application.services import MODEL_NOT_PROVIDED, DeleteJobResult
+from parsehawk.core.application.services import NOT_PROVIDED, DeleteJobResult
 from parsehawk.core.domain.errors import NotFoundError, ProviderRequestError, ValidationFailure
 from parsehawk.core.domain.models import ProviderName
 from parsehawk.core.domain.schemas import (
@@ -182,7 +182,7 @@ def create_extractor(request: CreateExtractorRequest, container: ContainerDep) -
         name=request.name,
         display_name=request.display_name,
         instructions=request.instructions,
-        enable_thinking=request.enable_thinking,
+        reasoning_effort=request.reasoning_effort,
         provider_name=request.provider_name,
         model=request.model,
         schema=request.schema_,
@@ -213,9 +213,11 @@ def update_extractor(
         extractor_ref,
         display_name=request.display_name,
         instructions=request.instructions,
-        enable_thinking=request.enable_thinking,
+        reasoning_effort=request.reasoning_effort
+        if "reasoning_effort" in request.model_fields_set
+        else NOT_PROVIDED,
         provider_name=request.provider_name,
-        model=request.model if "model" in request.model_fields_set else MODEL_NOT_PROVIDED,
+        model=request.model if "model" in request.model_fields_set else NOT_PROVIDED,
         schema=request.schema_,
         examples=[example.model_dump() for example in request.examples]
         if request.examples is not None
@@ -235,7 +237,7 @@ def upsert_extractor(
         body_name=request.name,
         display_name=request.display_name,
         instructions=request.instructions,
-        enable_thinking=request.enable_thinking,
+        reasoning_effort=request.reasoning_effort,
         provider_name=request.provider_name,
         model=request.model,
         schema=request.schema_,

--- a/src/parsehawk/server/api/fastapi/schemas.py
+++ b/src/parsehawk/server/api/fastapi/schemas.py
@@ -17,6 +17,7 @@ from parsehawk.core.domain.models import (
     JobStatus,
     Provider,
     ProviderName,
+    ReasoningEffort,
 )
 
 
@@ -39,7 +40,7 @@ class CreateExtractorRequest(ApiModel):
     name: str | None = None
     display_name: str | None = None
     instructions: str
-    enable_thinking: bool = False
+    reasoning_effort: ReasoningEffort | None = None
     provider_name: ProviderName | None = None
     model: str | None = None
     schema_: dict[str, Any] = Field(alias="schema")
@@ -57,7 +58,9 @@ class UpdateExtractorRequest(ApiModel):
 
     display_name: str | None = None
     instructions: str | None = None
-    enable_thinking: bool | None = None
+    # None is a meaningful value here ("use the model's default"); the endpoint
+    # checks model_fields_set to tell an explicit null from an absent field.
+    reasoning_effort: ReasoningEffort | None = None
     provider_name: ProviderName | None = None
     model: str | None = None
     schema_: dict[str, Any] | None = Field(default=None, alias="schema")
@@ -68,7 +71,7 @@ class UpsertExtractorRequest(ApiModel):
     name: str | None = None
     display_name: str
     instructions: str
-    enable_thinking: bool = False
+    reasoning_effort: ReasoningEffort | None = None
     provider_name: ProviderName | None = None
     model: str | None = None
     schema_: dict[str, Any] = Field(alias="schema")
@@ -161,7 +164,7 @@ class ExtractorResponse(ApiModel):
     name: str
     display_name: str
     instructions: str
-    enable_thinking: bool
+    reasoning_effort: ReasoningEffort | None
     provider_name: ProviderName | None
     model: str | None
     schema_: dict[str, Any] = Field(alias="schema")

--- a/src/parsehawk/server/api/fastapi/schemas.py
+++ b/src/parsehawk/server/api/fastapi/schemas.py
@@ -22,7 +22,7 @@ from parsehawk.core.domain.models import (
 
 
 class ApiModel(BaseModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra="forbid")
 
 
 class ExampleInputRequest(ApiModel):
@@ -54,8 +54,6 @@ class CreateExtractorRequest(ApiModel):
 
 
 class UpdateExtractorRequest(ApiModel):
-    model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra="forbid")
-
     display_name: str | None = None
     instructions: str | None = None
     # None is a meaningful value here ("use the model's default"); the endpoint
@@ -176,11 +174,21 @@ class ExtractorResponse(ApiModel):
 
     @classmethod
     def from_domain(cls, extractor: Extractor) -> ExtractorResponse:
-        payload = extractor.model_dump()
-        payload["schema"] = extractor.schema
-        payload["examples"] = [example.model_dump() for example in extractor.examples]
-        payload["is_prebuilt"] = extractor.is_prebuilt
-        return cls.model_validate(payload)
+        return cls(
+            id=extractor.id,
+            name=extractor.name,
+            display_name=extractor.display_name,
+            instructions=extractor.instructions,
+            reasoning_effort=extractor.reasoning_effort,
+            provider_name=extractor.provider_name,
+            model=extractor.model,
+            schema=extractor.schema,
+            examples=[example.model_dump() for example in extractor.examples],
+            source=extractor.source,
+            is_prebuilt=extractor.is_prebuilt,
+            created_at=extractor.created_at,
+            updated_at=extractor.updated_at,
+        )
 
 
 class ProviderResponse(ApiModel):

--- a/src/parsehawk/server/runtime/inference/generic.py
+++ b/src/parsehawk/server/runtime/inference/generic.py
@@ -29,11 +29,6 @@ RESPONSE_FORMAT_JSON_SCHEMA = "json_schema"
 RESPONSE_FORMAT_JSON_OBJECT = "json_object"
 RESPONSE_FORMAT_NONE = "none"
 
-# How a request's enable_thinking flag maps onto a provider's reasoning control.
-REASONING_NONE = "none"
-REASONING_CHAT_TEMPLATE_KWARGS = "chat_template_kwargs"
-REASONING_EFFORT = "reasoning_effort"
-
 # NuExtract3's semantic-type reference, vendored verbatim from
 # https://huggingface.co/numind/NuExtract3/blob/main/TYPES.md
 NUEXTRACT_TYPES_REFERENCE = (
@@ -47,8 +42,6 @@ def build_generic_chat_payload(
     model: str,
     max_completion_tokens: int,
     response_format_mode: str = RESPONSE_FORMAT_JSON_SCHEMA,
-    reasoning_mode: str = REASONING_NONE,
-    reasoning_effort: str = "medium",
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Return ``(standard_kwargs, extra_body)`` for the OpenAI chat client.
 
@@ -83,11 +76,10 @@ def build_generic_chat_payload(
     elif response_format_mode == RESPONSE_FORMAT_JSON_OBJECT:
         payload["response_format"] = {"type": "json_object"}
 
-    if request.enable_thinking:
-        if reasoning_mode == REASONING_EFFORT:
-            payload["reasoning_effort"] = reasoning_effort
-        elif reasoning_mode == REASONING_CHAT_TEMPLATE_KWARGS:
-            extra_body["chat_template_kwargs"] = {"enable_thinking": True}
+    # None means "the model's own default": send no reasoning parameter at all.
+    # Whether an explicit value is valid for this model is the provider's call.
+    if request.reasoning_effort is not None:
+        payload["reasoning_effort"] = str(request.reasoning_effort)
 
     return payload, extra_body
 

--- a/src/parsehawk/server/runtime/inference/openai_engine.py
+++ b/src/parsehawk/server/runtime/inference/openai_engine.py
@@ -22,13 +22,12 @@ from openai import APIConnectionError, APIStatusError, OpenAI
 from parsehawk import tracing
 from parsehawk.core.application.ports import ExtractionRequest, ExtractionResponse
 from parsehawk.core.domain.errors import ExtractionCancelled, ProviderRequestError
-from parsehawk.core.domain.models import NUEXTRACT3_MODELS
+from parsehawk.core.domain.models import NUEXTRACT3_MODELS, ReasoningEffort
 from parsehawk.server.runtime.inference._response import (
     message_content_with_source,
     redact_model_io,
 )
 from parsehawk.server.runtime.inference.generic import (
-    REASONING_NONE,
     RESPONSE_FORMAT_JSON_SCHEMA,
     build_generic_chat_payload,
 )
@@ -80,6 +79,15 @@ def select_adapter(model: str) -> str:
     return ADAPTER_NUEXTRACT if model in NUEXTRACT3_MODELS else ADAPTER_GENERIC
 
 
+def reasoning_requested(reasoning_effort: str | None) -> bool:
+    """Whether the request explicitly turns model reasoning on.
+
+    ``None`` leaves the model at its own default and ``"none"`` disables
+    reasoning; every explicit level enables it.
+    """
+    return reasoning_effort is not None and reasoning_effort != ReasoningEffort.NONE
+
+
 def _requires_legacy_max_tokens(exc: ProviderRequestError) -> bool:
     """Whether a 400 means the server rejects `max_completion_tokens` (legacy server)."""
     return exc.status_code == 400 and "max_completion_tokens" in str(exc)
@@ -95,8 +103,6 @@ class OpenAIEngineConfig:
     timeout_seconds: int = 600
     include_response_format: bool = True
     response_format_mode: str = RESPONSE_FORMAT_JSON_SCHEMA
-    reasoning_mode: str = REASONING_NONE
-    reasoning_effort: str = "medium"
     log_model_io: bool = False
 
 
@@ -136,7 +142,7 @@ class OpenAIExtractionEngine:
         raise_if_cancelled()
         self._debug_model_io("model runtime response: %s", raw)
         content = strip_generation_control_tokens(message_content_with_source(raw).text)
-        if request.enable_thinking:
+        if reasoning_requested(request.reasoning_effort):
             content = strip_hidden_thinking(content)
         return ExtractionResponse(data=extract_json_object(content))
 
@@ -200,12 +206,14 @@ class OpenAIExtractionEngine:
 
     def _build_payload(self, request: ExtractionRequest) -> tuple[dict[str, Any], dict[str, Any]]:
         if self._adapter == ADAPTER_NUEXTRACT:
+            # NuExtract's chat template only knows thinking on/off, so any
+            # explicit effort level maps to "on"; None/"none" map to "off".
             payload = build_chat_completion_payload(
                 request,
                 model=self._config.model,
                 max_tokens=self._config.max_tokens,
                 temperature=self._config.temperature,
-                enable_thinking=request.enable_thinking,
+                enable_thinking=reasoning_requested(request.reasoning_effort),
                 include_response_format=self._config.include_response_format,
                 include_enable_thinking_field=False,
             )
@@ -215,8 +223,6 @@ class OpenAIExtractionEngine:
             model=self._config.model,
             max_completion_tokens=self._config.max_tokens,
             response_format_mode=self._config.response_format_mode,
-            reasoning_mode=self._config.reasoning_mode,
-            reasoning_effort=self._config.reasoning_effort,
         )
 
     def _debug_model_io(self, message: str, payload: dict[str, Any]) -> None:

--- a/tests/integration/api/test_api_workflow.py
+++ b/tests/integration/api/test_api_workflow.py
@@ -75,7 +75,7 @@ def test_receipt_api_workflow(monkeypatch, tmp_path, mock_inference) -> None:
                 "name": "receipt_test",
                 "display_name": "Receipt Test",
                 "instructions": "Extract the receipt fields.",
-                "enable_thinking": True,
+                "reasoning_effort": "medium",
                 "schema": schema,
                 "examples": [],
             },
@@ -87,7 +87,7 @@ def test_receipt_api_workflow(monkeypatch, tmp_path, mock_inference) -> None:
         assert "json_schema" not in extractor_payload
         assert extractor_payload["source"] == "user"
         assert extractor_payload["is_prebuilt"] is False
-        assert extractor_payload["enable_thinking"] is True
+        assert extractor_payload["reasoning_effort"] == "medium"
         assert extractor_payload["schema"] == canonical_schema
         extractor_id = extractor_payload["id"]
         assert file_id.startswith("file_")

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -159,7 +159,8 @@ def test_extractors_create_reads_schema_and_examples(
             str(schema_path),
             "--examples",
             str(examples_path),
-            "--enable-thinking",
+            "--reasoning-effort",
+            "high",
             "--api-url",
             "http://api",
         ]
@@ -174,7 +175,7 @@ def test_extractors_create_reads_schema_and_examples(
                 "display_name": "Invoices",
                 "name": "invoices",
                 "instructions": "Extract invoice fields.",
-                "enable_thinking": True,
+                "reasoning_effort": "high",
                 "schema": {"type": "object"},
                 "examples": [{"input": "hi", "output": {"answer": "ok"}}],
             },
@@ -223,7 +224,6 @@ def test_extractors_put_replaces_by_name(tmp_path, monkeypatch: pytest.MonkeyPat
             {
                 "display_name": "Invoice",
                 "instructions": "Extract.",
-                "enable_thinking": False,
                 "schema": {"type": "object"},
                 "examples": [],
             },
@@ -407,7 +407,8 @@ def test_extract_creates_ad_hoc_extractor_uploads_file_and_waits(
             "--wait",
             "--poll-seconds",
             "0",
-            "--enable-thinking",
+            "--reasoning-effort",
+            "medium",
             "--api-url",
             "http://api",
         ]
@@ -422,7 +423,7 @@ def test_extract_creates_ad_hoc_extractor_uploads_file_and_waits(
             {
                 "display_name": "invoice_extractor",
                 "instructions": "Extract invoice fields.",
-                "enable_thinking": True,
+                "reasoning_effort": "medium",
                 "schema": {"type": "object"},
                 "examples": [],
             },
@@ -1479,6 +1480,7 @@ def test_migrate_status_reports_applied_and_pending(
             "20260708112000_remove_foundry_api_version_config",
             "20260708130000_inherit_openai_compatible_default_model",
             "20260708133000_job_execution_model_metadata",
+            "20260709090000_extractor_reasoning_effort",
         ],
     }
 
@@ -1495,6 +1497,7 @@ def test_migrate_status_reports_applied_and_pending(
             "20260708112000_remove_foundry_api_version_config",
             "20260708130000_inherit_openai_compatible_default_model",
             "20260708133000_job_execution_model_metadata",
+            "20260709090000_extractor_reasoning_effort",
         ],
         "pending": [],
     }
@@ -1523,12 +1526,13 @@ def test_apply_migrations_at_start_applies_when_not_excluded(
 
     assert database_path.exists()
     assert (
-        "Applied 7 migration(s): 20260701092442_initial_schema, "
+        "Applied 8 migration(s): 20260701092442_initial_schema, "
         "20260701121138_add_providers, 20260702160000_extractor_display_names, "
         "20260708093000_provider_configuration, "
         "20260708112000_remove_foundry_api_version_config, "
         "20260708130000_inherit_openai_compatible_default_model, "
-        "20260708133000_job_execution_model_metadata" in capsys.readouterr().out
+        "20260708133000_job_execution_model_metadata, "
+        "20260709090000_extractor_reasoning_effort" in capsys.readouterr().out
     )
 
 

--- a/tests/unit/core/test_services.py
+++ b/tests/unit/core/test_services.py
@@ -33,6 +33,7 @@ from parsehawk.core.domain.models import (
     JobStatus,
     Provider,
     ProviderName,
+    ReasoningEffort,
 )
 
 DEFAULT_MODEL = "numind/NuExtract3-W4A16"
@@ -391,12 +392,12 @@ def test_extractor_service_create_update_list_delete(services) -> None:
     extractor = extractor_service.create(
         name="receipt",
         instructions="classify",
-        enable_thinking=True,
+        reasoning_effort=ReasoningEffort.HIGH,
         schema=schema(),
         examples=[{"input": "x", "output": {"receipt_id": "2"}}],
     )
 
-    assert extractor.enable_thinking is True
+    assert extractor.reasoning_effort is ReasoningEffort.HIGH
     assert extractor.examples[0].output == {"receipt_id": "2"}
     assert extractor.examples[0].input.type == ExampleInputKind.TEXT
     assert extractor.examples[0].input.text == "x"
@@ -406,14 +407,14 @@ def test_extractor_service_create_update_list_delete(services) -> None:
         extractor.id,
         display_name="Receipt v2",
         instructions="classify better",
-        enable_thinking=False,
+        reasoning_effort=None,
         schema=schema(),
         examples=[],
     )
     assert updated.name == "receipt"
     assert updated.display_name == "Receipt v2"
     assert updated.instructions == "classify better"
-    assert updated.enable_thinking is False
+    assert updated.reasoning_effort is None
     assert updated.schema == derived_schema()
     assert updated.examples == []
     assert updated.updated_at >= extractor.updated_at
@@ -431,10 +432,18 @@ def test_extractor_service_partial_update_and_invalid_schema(services) -> None:
     assert updated.name == "a"
     assert updated.display_name == "a"
     assert updated.instructions == "new"
-    assert updated.enable_thinking is False
+    assert updated.reasoning_effort is None
 
-    updated = extractor_service.update(extractor.id, enable_thinking=True)
-    assert updated.enable_thinking is True
+    updated = extractor_service.update(extractor.id, reasoning_effort=ReasoningEffort.MEDIUM)
+    assert updated.reasoning_effort is ReasoningEffort.MEDIUM
+
+    # An update that omits the field leaves the explicit effort untouched …
+    updated = extractor_service.update(extractor.id, instructions="newer")
+    assert updated.reasoning_effort is ReasoningEffort.MEDIUM
+
+    # … while an explicit None resets to the model's own default.
+    updated = extractor_service.update(extractor.id, reasoning_effort=None)
+    assert updated.reasoning_effort is None
 
     with pytest.raises(ValidationFailure):
         extractor_service.create(name="bad", instructions="bad", schema={"type": 1})
@@ -637,7 +646,10 @@ def test_job_service_create_list_get_delete_and_success(services) -> None:
         file_name="a.md", content_type="", content=b"Subject: #1#"
     )
     extractor = services["extractor_service"].create(
-        name="receipt", instructions="classify", enable_thinking=True, schema=schema()
+        name="receipt",
+        instructions="classify",
+        reasoning_effort=ReasoningEffort.MEDIUM,
+        schema=schema(),
     )
 
     job_service: JobService = services["job_service"]
@@ -656,7 +668,7 @@ def test_job_service_create_list_get_delete_and_success(services) -> None:
     assert services["engine"].requests[0].source_text == "Subject: #1#"
     assert services["engine"].requests[0].source_storage_path == file.storage_path
     assert services["engine"].requests[0].source_content_type == file.content_type
-    assert services["engine"].requests[0].enable_thinking is True
+    assert services["engine"].requests[0].reasoning_effort is ReasoningEffort.MEDIUM
 
     assert job_service.delete(job.id) == DeleteJobResult.DELETED
     with pytest.raises(NotFoundError):

--- a/tests/unit/server/test_api_schemas.py
+++ b/tests/unit/server/test_api_schemas.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from parsehawk.core.domain.models import (
+    Extractor,
+    ExtractorSource,
+    File,
+    FileSource,
+    ReasoningEffort,
+)
+from parsehawk.server.api.fastapi.schemas import ExtractorResponse, FileResponse
+
+
+def test_response_helpers_only_emit_public_file_fields() -> None:
+    file = File(
+        id="file_1",
+        file_name="receipt.md",
+        content_type="text/markdown",
+        size_bytes=12,
+        sha256="abc123",
+        storage_path="/private/receipt.md",
+        source=FileSource.EXAMPLE,
+        seed_key="fixture:receipt",
+        seed_version=1,
+    )
+
+    payload = FileResponse.from_domain(file).model_dump(mode="json")
+
+    assert payload["is_example"] is True
+    assert "storage_path" not in payload
+    assert "seed_key" not in payload
+    assert "seed_version" not in payload
+
+    with pytest.raises(ValidationError):
+        FileResponse.model_validate({**payload, "storage_path": "/private/receipt.md"})
+
+
+def test_response_helpers_only_emit_public_extractor_fields() -> None:
+    extractor = Extractor(
+        id="extractor_1",
+        name="receipt",
+        display_name="Receipt",
+        instructions="Extract receipt fields.",
+        reasoning_effort=ReasoningEffort.MEDIUM,
+        schema={"type": "object", "properties": {}},
+        examples=[],
+        source=ExtractorSource.PREBUILT,
+        seed_key="prebuilt:receipt:v1",
+        seed_version=1,
+    )
+
+    payload = ExtractorResponse.from_domain(extractor).model_dump(by_alias=True, mode="json")
+
+    assert payload["is_prebuilt"] is True
+    assert payload["schema"] == {"type": "object", "properties": {}}
+    assert "schema_" not in payload
+    assert "seed_key" not in payload
+    assert "seed_version" not in payload
+
+    with pytest.raises(ValidationError):
+        ExtractorResponse.model_validate({**payload, "seed_key": "prebuilt:receipt:v1"})

--- a/tests/unit/server/test_migrations.py
+++ b/tests/unit/server/test_migrations.py
@@ -30,6 +30,7 @@ INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID = (
     "20260708130000_inherit_openai_compatible_default_model"
 )
 JOB_EXECUTION_MODEL_METADATA_ID = "20260708133000_job_execution_model_metadata"
+EXTRACTOR_REASONING_EFFORT_ID = "20260709090000_extractor_reasoning_effort"
 ALL_MIGRATION_IDS = [
     BASELINE_ID,
     ADD_PROVIDERS_ID,
@@ -38,6 +39,7 @@ ALL_MIGRATION_IDS = [
     REMOVE_FOUNDRY_API_VERSION_CONFIG_ID,
     INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
     JOB_EXECUTION_MODEL_METADATA_ID,
+    EXTRACTOR_REASONING_EFFORT_ID,
 ]
 
 # The full current schema after all migrations. ALTER-added columns
@@ -60,7 +62,6 @@ EXPECTED_COLUMNS = {
         "name",
         "display_name",
         "instructions",
-        "enable_thinking",
         "schema",
         "examples",
         "source",
@@ -70,6 +71,7 @@ EXPECTED_COLUMNS = {
         "updated_at",
         "provider_name",
         "model",
+        "reasoning_effort",
     ],
     "jobs": [
         "id",
@@ -387,6 +389,7 @@ def test_provider_configuration_migration_renames_foundry_without_data_loss(
         REMOVE_FOUNDRY_API_VERSION_CONFIG_ID,
         INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
         JOB_EXECUTION_MODEL_METADATA_ID,
+        EXTRACTOR_REASONING_EFFORT_ID,
     ]
 
     assert columns(conn, "providers") == EXPECTED_COLUMNS["providers"]
@@ -446,6 +449,7 @@ def test_remove_foundry_api_version_config_migration_strips_already_migrated_con
         REMOVE_FOUNDRY_API_VERSION_CONFIG_ID,
         INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
         JOB_EXECUTION_MODEL_METADATA_ID,
+        EXTRACTOR_REASONING_EFFORT_ID,
     ]
 
     provider = conn.execute(
@@ -512,6 +516,7 @@ def test_inherit_openai_compatible_default_model_migration_preserves_custom_mode
     assert apply_pending(conn) == [
         INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
         JOB_EXECUTION_MODEL_METADATA_ID,
+        EXTRACTOR_REASONING_EFFORT_ID,
     ]
 
     models = {
@@ -522,6 +527,83 @@ def test_inherit_openai_compatible_default_model_migration_preserves_custom_mode
         "extractor_custom_local": "custom/local-model",
         "extractor_default": None,
         "extractor_openai": "numind/NuExtract3-W4A16",
+    }
+
+
+def test_extractor_reasoning_effort_migration_backfills_per_adapter(
+    conn: sqlite3.Connection,
+) -> None:
+    _register_functions(conn)
+    applied_ids = [
+        BASELINE_ID,
+        ADD_PROVIDERS_ID,
+        EXTRACTOR_DISPLAY_NAMES_ID,
+        PROVIDER_CONFIGURATION_ID,
+        REMOVE_FOUNDRY_API_VERSION_CONFIG_ID,
+        INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
+        JOB_EXECUTION_MODEL_METADATA_ID,
+    ]
+    for migration_id in applied_ids:
+        migration = next(
+            migration for migration in discover_migrations() if migration.id == migration_id
+        )
+        conn.executescript(migration.path.read_text(encoding="utf-8"))
+    conn.execute("CREATE TABLE schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL)")
+    conn.executemany(
+        "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+        [(migration_id, "t") for migration_id in applied_ids],
+    )
+    rows = [
+        # (id, enable_thinking, model): thinking only had a request effect for
+        # NuExtract3 models (a NULL model inherits the bundled NuExtract runtime).
+        ("extractor_nuextract_on", 1, "numind/NuExtract3-W4A16"),
+        ("extractor_nuextract_off", 0, "numind/NuExtract3-W4A16"),
+        ("extractor_inherited_on", 1, None),
+        ("extractor_gpt4o_on", 1, "gpt-4o"),
+        ("extractor_gpt4o_off", 0, "gpt-4o"),
+    ]
+    for extractor_id, enable_thinking, model in rows:
+        conn.execute(
+            """
+            INSERT INTO extractors (
+                id, name, display_name, instructions, enable_thinking, schema, examples,
+                source, seed_key, seed_version, created_at, updated_at, provider_name, model
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                extractor_id,
+                extractor_id.removeprefix("extractor_").replace("_", "-"),
+                extractor_id,
+                "Extract.",
+                enable_thinking,
+                "{}",
+                "[]",
+                "user",
+                None,
+                None,
+                "t0",
+                "t1",
+                "openai_compatible_api" if model is None else "openai",
+                model,
+            ),
+        )
+    conn.commit()
+
+    assert apply_pending(conn) == [EXTRACTOR_REASONING_EFFORT_ID]
+
+    assert "enable_thinking" not in columns(conn, "extractors")
+    efforts = {
+        row["id"]: row["reasoning_effort"]
+        for row in conn.execute("SELECT id, reasoning_effort FROM extractors")
+    }
+    assert efforts == {
+        "extractor_nuextract_on": "medium",
+        "extractor_nuextract_off": None,
+        "extractor_inherited_on": "medium",
+        # enable_thinking never sent anything for generic models, so the
+        # backfill must not start sending reasoning_effort (gpt-4o rejects it).
+        "extractor_gpt4o_on": None,
+        "extractor_gpt4o_off": None,
     }
 
 

--- a/tests/unit/server/test_nuextract.py
+++ b/tests/unit/server/test_nuextract.py
@@ -131,7 +131,7 @@ def test_build_chat_completion_payload_uses_nuextract_message_structure() -> Non
     request = ExtractionRequest(
         source_text="John bought coffee.",
         instructions="Extract buyer and item.",
-        enable_thinking=False,
+        reasoning_effort=None,
         schema={
             "type": "object",
             "properties": {
@@ -201,7 +201,7 @@ def test_build_chat_completion_payload_vllm_flavor_keeps_response_format() -> No
             "properties": {"buyer": {"type": "string"}},
         },
         examples=[],
-        enable_thinking=True,
+        reasoning_effort="medium",
     )
 
     payload = build_chat_completion_payload(
@@ -234,7 +234,7 @@ def test_build_chat_completion_payload_derives_nuextract_template_from_schema() 
     request = ExtractionRequest(
         source_text="Jane bought tea.",
         instructions="Extract buyer and item.",
-        enable_thinking=False,
+        reasoning_effort=None,
         schema={
             "type": "object",
             "properties": {
@@ -273,7 +273,7 @@ def test_build_chat_completion_payload_includes_prepared_images_in_order(tmp_pat
             PreparedImage(storage_path=str(second), content_type="image/png", page_number=2),
         ],
         instructions="Extract invoice fields.",
-        enable_thinking=False,
+        reasoning_effort=None,
         schema={
             "type": "object",
             "properties": {"invoice_number": {"type": "string"}},

--- a/tests/unit/server/test_openai_engine.py
+++ b/tests/unit/server/test_openai_engine.py
@@ -11,8 +11,6 @@ from parsehawk.core.application.ports import ExtractionRequest
 from parsehawk.core.domain.errors import ExtractionCancelled, ProviderRequestError
 from parsehawk.server.runtime.inference import openai_engine as openai_engine_module
 from parsehawk.server.runtime.inference.generic import (
-    REASONING_CHAT_TEMPLATE_KWARGS,
-    REASONING_EFFORT,
     RESPONSE_FORMAT_JSON_OBJECT,
     RESPONSE_FORMAT_NONE,
     build_generic_chat_payload,
@@ -26,11 +24,13 @@ from parsehawk.server.runtime.inference.openai_engine import (
 NUEXTRACT_MODEL = "numind/NuExtract3-W4A16"
 
 
-def make_request(*, enable_thinking: bool = False, examples: list[dict[str, Any]] | None = None):
+def make_request(
+    *, reasoning_effort: str | None = None, examples: list[dict[str, Any]] | None = None
+):
     return ExtractionRequest(
         source_text="Receipt #2",
         instructions="Extract the receipt id.",
-        enable_thinking=enable_thinking,
+        reasoning_effort=reasoning_effort,
         schema={
             "type": "object",
             "properties": {"receipt_id": {"type": "string"}},
@@ -166,7 +166,7 @@ def test_nuextract_thinking_uses_final_content_after_reasoning() -> None:
     request = ExtractionRequest(
         source_text="Alex packed a blue notebook.",
         instructions="Extract the person and object.",
-        enable_thinking=True,
+        reasoning_effort="medium",
         schema={
             "type": "object",
             "properties": {
@@ -270,25 +270,39 @@ def test_generic_payload_response_format_modes_and_examples() -> None:
     assert "response_format" not in none_payload
 
 
-def test_generic_payload_routes_reasoning() -> None:
-    thinking = make_request(enable_thinking=True)
+def test_generic_payload_maps_reasoning_effort() -> None:
+    # The default (None) sends no reasoning parameter at all — the model's own
+    # default is the only setting that is safe for every model.
+    default, extra_body = build_generic_chat_payload(
+        make_request(), model="gpt-5.1", max_completion_tokens=1
+    )
+    assert "reasoning_effort" not in default
+    assert extra_body == {}
 
     effort, _ = build_generic_chat_payload(
-        thinking,
-        model="o3",
-        max_completion_tokens=1,
-        reasoning_mode=REASONING_EFFORT,
-        reasoning_effort="high",
+        make_request(reasoning_effort="high"), model="o3", max_completion_tokens=1
     )
     assert effort["reasoning_effort"] == "high"
 
-    _, extra_body = build_generic_chat_payload(
-        thinking,
-        model="qwen",
-        max_completion_tokens=1,
-        reasoning_mode=REASONING_CHAT_TEMPLATE_KWARGS,
+    # An explicit "none" is forwarded verbatim; whether the model accepts it is
+    # the provider's call.
+    disabled, _ = build_generic_chat_payload(
+        make_request(reasoning_effort="none"), model="gpt-5.1", max_completion_tokens=1
     )
-    assert extra_body["chat_template_kwargs"] == {"enable_thinking": True}
+    assert disabled["reasoning_effort"] == "none"
+
+
+def test_nuextract_adapter_maps_reasoning_effort_to_thinking_flag() -> None:
+    for reasoning_effort, expected in ((None, False), ("none", False), ("low", True)):
+        client, completions = _client_returning('{"receipt_id": "2"}')
+        engine = OpenAIExtractionEngine(
+            OpenAIEngineConfig(model=NUEXTRACT_MODEL), client=cast(OpenAI, client)
+        )
+
+        engine.extract(make_request(reasoning_effort=reasoning_effort))
+
+        (call,) = completions.calls
+        assert call["extra_body"]["chat_template_kwargs"]["enable_thinking"] is expected
 
 
 def test_extract_reads_reasoning_content_fallback() -> None:

--- a/tests/unit/server/test_providers_api.py
+++ b/tests/unit/server/test_providers_api.py
@@ -135,6 +135,64 @@ def test_update_extractor_model_can_be_omitted_or_cleared_for_local_default(
     assert inherited.json()["model"] is None
 
 
+def test_request_bodies_reject_unknown_fields(client: tuple[TestClient, Container]) -> None:
+    api, _container = client
+    cases = [
+        (
+            "POST",
+            "/v1/extractors",
+            {
+                "name": "strict_create",
+                "instructions": "i",
+                "schema": _OBJECT_SCHEMA,
+                "enable_thinking": True,
+            },
+            "enable_thinking",
+        ),
+        (
+            "PUT",
+            "/v1/extractors/strict_put",
+            {
+                "display_name": "Strict put",
+                "instructions": "i",
+                "schema": _OBJECT_SCHEMA,
+                "enable_thinking": True,
+            },
+            "enable_thinking",
+        ),
+        (
+            "PATCH",
+            "/v1/extractors/strict_patch",
+            {"enable_thinking": True},
+            "enable_thinking",
+        ),
+        (
+            "POST",
+            "/v1/jobs",
+            {"extractor_name": "receipt", "text": "Receipt #1", "unexpected": True},
+            "unexpected",
+        ),
+        (
+            "POST",
+            "/v1/schemas/validate",
+            {"schema": _OBJECT_SCHEMA, "unexpected": True},
+            "unexpected",
+        ),
+        (
+            "PATCH",
+            "/v1/providers/openai",
+            {"base_url": "https://proxy/v1", "unexpected": True},
+            "unexpected",
+        ),
+    ]
+
+    for method, path, payload, rejected_field in cases:
+        response = api.request(method, path, json=payload)
+
+        assert response.status_code == 422
+        assert rejected_field in response.text
+
+
 def test_list_openai_provider_models_uses_chat_filter(
     client: tuple[TestClient, Container], monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/unit/server/test_sqlite.py
+++ b/tests/unit/server/test_sqlite.py
@@ -19,6 +19,7 @@ from parsehawk.core.domain.models import (
     JobStatus,
     Provider,
     ProviderName,
+    ReasoningEffort,
     ValidationIssue,
 )
 from parsehawk.server.adapters.persistence.sqlite import (
@@ -63,7 +64,6 @@ def test_init_db_creates_structured_tables_indexes_and_foreign_keys(
         "name",
         "display_name",
         "instructions",
-        "enable_thinking",
         "schema",
         "examples",
         "source",
@@ -73,6 +73,7 @@ def test_init_db_creates_structured_tables_indexes_and_foreign_keys(
         "updated_at",
         "provider_name",
         "model",
+        "reasoning_effort",
     ]
     assert columns(conn, "jobs") == [
         "id",
@@ -351,7 +352,7 @@ def sample_extractor(id: str = "extractor_1") -> Extractor:
         name=f"receipt_{suffix}",
         display_name="Receipt",
         instructions="Extract receipt fields.",
-        enable_thinking=True,
+        reasoning_effort=ReasoningEffort.MEDIUM,
         schema={
             "type": "object",
             "properties": {"receipt_id": {"type": "string"}},


### PR DESCRIPTION
Closes #59.
Closes #114.

Implements the plan from https://github.com/parsehawk/parsehawk/issues/59#issuecomment-4916223754: replaces the boolean `enable_thinking` with a nullable `reasoning_effort` (`none | minimal | low | medium | high | xhigh`) on the extractor, end to end.

## What changed

- **Domain/API/CLI/UI**: `Extractor.reasoning_effort: ReasoningEffort | None`. `null` (default) sends no reasoning parameter — the model's own default, safe for every model. The Web UI's thinking toggle becomes a "Reasoning effort" dropdown; the CLI gains `--reasoning-effort` (with `default` as the explicit reset spelling on `update`).
- **Request-carried, not engine-config**: the effort rides on `ExtractionRequest`, so `EngineFactory` and its per-(provider, model) engine cache are untouched. The never-wired `reasoning_mode`/`reasoning_effort` knobs on `OpenAIEngineConfig` and the dead `chat_template_kwargs` branch in the generic adapter are deleted.
- **Adapter mapping**: generic adapter forwards any non-null effort as `reasoning_effort`; NuExtract3 maps `null`/`none` → thinking off, any level → thinking on. `strip_hidden_thinking` now gates on "reasoning requested" (`effort not in {null, none}`).
- **Migration with conditional backfill**: `enable_thinking=1` becomes `'medium'` only for NuExtract3 models (including `model IS NULL`, which inherits the bundled runtime); for generic models the flag was a request no-op, so it becomes `NULL` — a gpt-4o extractor with the stale flag keeps working instead of newly 400ing.
- **Tri-state PATCH**: absent field = leave unchanged, explicit `null` = reset to model default, via `model_fields_set` (same pattern as `model`).
- **No capability gating**: model×effort compatibility is left to the provider (Azure deployment names make a server-side matrix infeasible); the provider's 400 already reaches the job error, which the UI renders.

## Verification

- `just lint` / `just typecheck` / backend tests: 293 passed, 100% coverage.
- Web: `typecheck`, 34 tests, production build — all green.
- **macOS Apple Silicon (vLLM Metal)**: `parsehawk restart` + `just e2e` → 18 passed.
- Manual API smoke against the live server: create with `medium`; PATCH without the field keeps `medium`; PATCH `null` resets; invalid value 422s.
- **Linux/NVIDIA (Docker Compose vLLM runtime)**: test suite run clean (verified manually) — both supported local-runtime platforms verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



