### PR TITLE
fix(vllm): pin vLLM Metal runtime versions on macOS

### DIFF
--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -641,7 +641,8 @@ def dev(args: argparse.Namespace) -> None:
             runtime_cmd[0] = str(
                 ensure_vllm_metal_venv(
                     settings.vllm_metal_home,
-                    install_url=settings.vllm_metal_install_url,
+                    vllm_version=settings.vllm_metal_vllm_version,
+                    vllm_metal_version=settings.vllm_metal_version,
                 )
             )
         else:
@@ -857,7 +858,8 @@ def start_docker(args: argparse.Namespace) -> None:
                     python=str(
                         ensure_vllm_metal_venv(
                             settings.vllm_metal_home,
-                            install_url=settings.vllm_metal_install_url,
+                            vllm_version=settings.vllm_metal_vllm_version,
+                            vllm_metal_version=settings.vllm_metal_version,
                         )
                     ),
                 ),

--- a/src/parsehawk/config.py
+++ b/src/parsehawk/config.py
@@ -18,9 +18,12 @@ DEFAULT_VLLM_PYTHON_VERSION = "3.12"
 DEFAULT_NUEXTRACT_KEEP_ALIVE_SECONDS = 300
 DEFAULT_PDF_MAX_PAGES = 25
 DEFAULT_PDF_RENDER_DPI = 170
-DEFAULT_VLLM_METAL_INSTALL_URL = (
-    "https://raw.githubusercontent.com/vllm-project/vllm-metal/main/install.sh"
-)
+# The vLLM Metal runtime is provisioned from two pinned artifacts: the vLLM
+# source release the plugin was built against, and the vllm-metal wheel from
+# the matching GitHub release tag. Bump both together — a vllm-metal release
+# pins its vLLM version in the upstream install.sh at the same tag.
+DEFAULT_VLLM_METAL_VERSION = "0.3.0.dev20260708043308"
+DEFAULT_VLLM_METAL_VLLM_VERSION = "0.24.0"
 
 
 def default_inference_engine() -> str | None:
@@ -69,7 +72,8 @@ class Settings(BaseSettings):
     vllm_metal_home: Path = Field(
         default_factory=lambda: Path.home() / ".parsehawk" / "runtimes" / "vllm-metal"
     )
-    vllm_metal_install_url: str = DEFAULT_VLLM_METAL_INSTALL_URL
+    vllm_metal_version: str = DEFAULT_VLLM_METAL_VERSION
+    vllm_metal_vllm_version: str = DEFAULT_VLLM_METAL_VLLM_VERSION
     nuextract_keep_alive_seconds: int = Field(default=DEFAULT_NUEXTRACT_KEEP_ALIVE_SECONDS, ge=0)
     pdf_max_pages: int = Field(default=DEFAULT_PDF_MAX_PAGES, ge=1)
     pdf_render_dpi: int = Field(default=DEFAULT_PDF_RENDER_DPI, ge=1)

--- a/src/parsehawk/server/runtime/vllm_env.py
+++ b/src/parsehawk/server/runtime/vllm_env.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
@@ -54,19 +55,40 @@ def vllm_launch_env(*, metal_memory_fraction: float | None = None) -> dict[str, 
     return env
 
 
+# The upstream vllm-metal releases ship a single cp312 wheel, so the Metal
+# venv's Python is fixed independently of the (configurable) Linux venv Python.
+VLLM_METAL_PYTHON_VERSION = "3.12"
+
+
+def vllm_metal_wheel_url(version: str) -> str:
+    return (
+        "https://github.com/vllm-project/vllm-metal/releases/download/"
+        f"v{version}/vllm_metal-{version}-cp312-cp312-macosx_11_0_arm64.whl"
+    )
+
+
 def ensure_vllm_metal_venv(
     runtime_home: Path,
     *,
-    install_url: str,
+    vllm_version: str,
+    vllm_metal_version: str,
     log: Callable[[str], None] = print,
 ) -> Path:
-    """Ensure a vLLM Metal environment exists for macOS Apple Silicon.
+    """Ensure a pinned vLLM Metal environment exists for macOS Apple Silicon.
 
-    The upstream installer currently owns the fast-moving vLLM Metal dependency
-    graph. ParseHawk keeps this setup contained by pointing ``HOME`` at a
-    ParseHawk runtime directory, which makes the installer create
-    ``<runtime_home>/.venv-vllm-metal``. If the user already has the upstream
-    default environment, reuse it to avoid a duplicate multi-GB install.
+    The upstream ``install.sh`` is a moving target: it installs whatever
+    vllm-metal wheel is the *latest* GitHub release, against whatever vLLM
+    version the script pins on ``main`` that day. ParseHawk instead replicates
+    the installer's steps with pinned versions so every install is
+    reproducible: build the pinned vLLM source release (with its CPU
+    requirements set), then install the vllm-metal wheel from the matching
+    release tag. The marker records the pin, so bumping either version
+    rebuilds the venv.
+
+    Escape hatches, both of which bypass the pin and leave the environment
+    user-managed: ``PARSEHAWK_VLLM_METAL_PYTHON`` points at an explicit
+    interpreter, and an existing upstream default environment
+    (``~/.venv-vllm-metal``) is reused to avoid a duplicate multi-GB install.
     """
     configured_python = os.getenv("PARSEHAWK_VLLM_METAL_PYTHON")
     if configured_python:
@@ -76,9 +98,15 @@ def ensure_vllm_metal_venv(
     if upstream_python.exists():
         return upstream_python
 
-    python_bin = runtime_home / ".venv-vllm-metal" / "bin" / "python"
+    venv_dir = runtime_home / ".venv-vllm-metal"
+    python_bin = venv_dir / "bin" / "python"
     marker = runtime_home / ".parsehawk-ready"
-    if python_bin.exists() and marker.exists():
+    spec = f"vllm=={vllm_version} vllm-metal=={vllm_metal_version}"
+    if (
+        python_bin.exists()
+        and marker.exists()
+        and marker.read_text(encoding="utf-8").strip() == spec
+    ):
         return python_bin
 
     uv = shutil.which("uv")
@@ -88,19 +116,63 @@ def ensure_vllm_metal_venv(
         )
     if shutil.which("curl") is None:
         raise SystemExit(
-            "`curl` is required to download the vLLM Metal installer but was not found on PATH."
+            "`curl` is required to download the vLLM source release but was not found on PATH."
         )
 
     runtime_home.mkdir(parents=True, exist_ok=True)
     log(
-        "Setting up the vLLM Metal runtime in "
-        f"{runtime_home / '.venv-vllm-metal'} (first run; this can take several minutes)..."
+        f"Setting up the vLLM Metal runtime in {venv_dir} "
+        f"({spec}; first run can take several minutes)..."
     )
-    env = {**os.environ, "HOME": str(runtime_home)}
-    subprocess.run(["bash", "-c", f"curl -fsSL {install_url} | bash"], env=env, check=True)
-    if not python_bin.exists():
-        raise SystemExit(f"vLLM Metal installer finished but {python_bin} was not created")
-    marker.write_text("vllm-metal\n", encoding="utf-8")
+    subprocess.run(
+        [uv, "venv", "--clear", "--python", VLLM_METAL_PYTHON_VERSION, "--seed", str(venv_dir)],
+        check=True,
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tarball = f"vllm-{vllm_version}.tar.gz"
+        source_url = (
+            f"https://github.com/vllm-project/vllm/releases/download/v{vllm_version}/{tarball}"
+        )
+        subprocess.run(["curl", "-fsSL", source_url, "-o", tarball], cwd=tmp, check=True)
+        subprocess.run(["tar", "xf", tarball], cwd=tmp, check=True)
+        source_dir = Path(tmp) / f"vllm-{vllm_version}"
+        # unsafe-best-match lets uv resolve the CPU torch builds across the
+        # extra indexes listed in the requirements set, as upstream does.
+        subprocess.run(
+            [
+                uv,
+                "pip",
+                "install",
+                "--python",
+                str(python_bin),
+                "-r",
+                "requirements/cpu.txt",
+                "--index-strategy",
+                "unsafe-best-match",
+            ],
+            cwd=source_dir,
+            check=True,
+        )
+        subprocess.run(
+            [uv, "pip", "install", "--python", str(python_bin), "."],
+            cwd=source_dir,
+            env={**os.environ, "CXXFLAGS": "-Wno-parentheses"},
+            check=True,
+        )
+
+    subprocess.run(
+        [
+            uv,
+            "pip",
+            "install",
+            "--python",
+            str(python_bin),
+            vllm_metal_wheel_url(vllm_metal_version),
+        ],
+        check=True,
+    )
+    marker.write_text(f"{spec}\n", encoding="utf-8")
     return python_bin
 
 

--- a/tests/unit/server/test_vllm_env.py
+++ b/tests/unit/server/test_vllm_env.py
@@ -47,6 +47,98 @@ def test_ensure_vllm_venv_reuses_cached_env_and_refreshes_patch(
     assert pth.strip() == f"import {vllm_env.PATCH_MODULE_NAME}"
 
 
+def _isolate_metal_escape_hatches(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PARSEHAWK_VLLM_METAL_PYTHON", raising=False)
+    monkeypatch.setattr(vllm_env.Path, "home", lambda: tmp_path / "home")
+
+
+def test_ensure_vllm_metal_venv_prefers_configured_python(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PARSEHAWK_VLLM_METAL_PYTHON", "/custom/bin/python")
+
+    python_bin = vllm_env.ensure_vllm_metal_venv(
+        tmp_path / "runtime", vllm_version="0.24.0", vllm_metal_version="0.3.0"
+    )
+
+    assert python_bin == Path("/custom/bin/python")
+
+
+def test_ensure_vllm_metal_venv_reuses_upstream_env(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_metal_escape_hatches(tmp_path, monkeypatch)
+    upstream_python = tmp_path / "home" / ".venv-vllm-metal" / "bin" / "python"
+    upstream_python.parent.mkdir(parents=True)
+    upstream_python.write_text("", encoding="utf-8")
+
+    python_bin = vllm_env.ensure_vllm_metal_venv(
+        tmp_path / "runtime", vllm_version="0.24.0", vllm_metal_version="0.3.0"
+    )
+
+    assert python_bin == upstream_python
+
+
+def test_ensure_vllm_metal_venv_reuses_pinned_env(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_metal_escape_hatches(tmp_path, monkeypatch)
+    runtime_home = tmp_path / "runtime"
+    python_bin = runtime_home / ".venv-vllm-metal" / "bin" / "python"
+    python_bin.parent.mkdir(parents=True)
+    python_bin.write_text("", encoding="utf-8")
+    (runtime_home / ".parsehawk-ready").write_text(
+        "vllm==0.24.0 vllm-metal==0.3.0\n", encoding="utf-8"
+    )
+
+    def fail(*args: object, **kwargs: object) -> None:
+        raise AssertionError("a cached venv must not be rebuilt")
+
+    monkeypatch.setattr(vllm_env.subprocess, "run", fail)
+
+    result = vllm_env.ensure_vllm_metal_venv(
+        runtime_home, vllm_version="0.24.0", vllm_metal_version="0.3.0"
+    )
+
+    assert result == python_bin
+
+
+def test_ensure_vllm_metal_venv_rebuilds_when_pin_changes(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _isolate_metal_escape_hatches(tmp_path, monkeypatch)
+    runtime_home = tmp_path / "runtime"
+    python_bin = runtime_home / ".venv-vllm-metal" / "bin" / "python"
+    python_bin.parent.mkdir(parents=True)
+    python_bin.write_text("", encoding="utf-8")
+    # Pre-pinning installs recorded a bare marker; they must rebuild too.
+    (runtime_home / ".parsehawk-ready").write_text("vllm-metal\n", encoding="utf-8")
+
+    calls: list[list[str]] = []
+    monkeypatch.setattr(vllm_env.shutil, "which", lambda name: f"/usr/bin/{name}")
+    monkeypatch.setattr(
+        vllm_env.subprocess, "run", lambda cmd, **kwargs: calls.append([str(c) for c in cmd])
+    )
+
+    vllm_env.ensure_vllm_metal_venv(
+        runtime_home,
+        vllm_version="0.24.0",
+        vllm_metal_version="0.3.0",
+        log=lambda _msg: None,
+    )
+
+    assert any(cmd[:2] == ["/usr/bin/uv", "venv"] for cmd in calls)
+    assert any(
+        "https://github.com/vllm-project/vllm/releases/download/v0.24.0/vllm-0.24.0.tar.gz" in cmd
+        for cmd in calls
+    )
+    assert any("requirements/cpu.txt" in cmd for cmd in calls)
+    assert any(vllm_env.vllm_metal_wheel_url("0.3.0") in cmd for cmd in calls)
+    assert (runtime_home / ".parsehawk-ready").read_text(
+        encoding="utf-8"
+    ).strip() == "vllm==0.24.0 vllm-metal==0.3.0"
+
+
 def test_ensure_vllm_venv_rebuilds_when_spec_changes(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Closes #106

## Problem

The macOS Apple Silicon runtime was provisioned by piping the upstream vllm-metal `install.sh` from `main` into bash. That flow is unpinned three times over:

- the script itself tracks `main`
- it sources `lib.sh` from `main`
- it installs whatever vllm-metal wheel is the **latest** GitHub release, against whatever vLLM version the script pins that day

Two machines set up on different days got different runtimes, and a bad upstream nightly could break `parsehawk start` with no way to hold back.

## Change

Replicate the installer's steps inline with pinned versions (`vllm==0.24.0`, `vllm-metal==0.3.0.dev20260708043308` — the version pair from the same release tag):

1. `uv venv --clear --python 3.12 --seed` in the ParseHawk runtime home
2. build the pinned vLLM source release with its `requirements/cpu.txt` set (`--index-strategy unsafe-best-match`, `CXXFLAGS=-Wno-parentheses`, as upstream does)
3. install the vllm-metal wheel from the matching release tag

The ready-marker now records the pin (mirroring the Linux venv's pip-spec marker), so bumping either version — or upgrading from a pre-pinning install — rebuilds the venv in place. New settings: `PARSEHAWK_VLLM_METAL_VERSION` / `PARSEHAWK_VLLM_METAL_VLLM_VERSION` replace `PARSEHAWK_VLLM_METAL_INSTALL_URL`. The `PARSEHAWK_VLLM_METAL_PYTHON` override and upstream `~/.venv-vllm-metal` reuse remain as explicitly user-managed escape hatches.

## Verification

- `just check`-level gates: ruff format/lint, ty, full unit suite (301 passed, 100% coverage gate)
- **macOS Apple Silicon**: `parsehawk restart` on a machine with a legacy (marker `vllm-metal`) install — correctly detected the stale marker, rebuilt the venv from the pinned artifacts, wrote the pinned marker, and served the model; `just e2e` → 18 passed
- **Linux x86_64 / NVIDIA**: `parsehawk restart` + `just e2e` pass as well (the Linux path is untouched by this change — it already pins via `vllm_pip_spec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
