### PR TITLE
feat(runtime): default to 16k context on 16 GB Apple Silicon Macs

### DIFF
--- a/src/parsehawk/model_profiles.py
+++ b/src/parsehawk/model_profiles.py
@@ -72,6 +72,12 @@ DEFAULT_MODEL_RUNTIME_PROFILE = ModelRuntimeProfile(
                 max_num_seqs=1,
             ),
             RuntimeTier(
+                min_memory_bytes=16 * GIB,
+                max_model_len=16384,
+                gpu_memory_utilization=0.70,
+                max_num_seqs=1,
+            ),
+            RuntimeTier(
                 min_memory_bytes=32 * GIB,
                 max_model_len=32768,
                 gpu_memory_utilization=0.50,

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -638,6 +638,12 @@ def test_vllm_settings_default_to_macos_memory_tier(
 
     monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 18_000_000_000)
     resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
+    assert resolved.vllm_max_model_len == 16384
+    assert resolved.vllm_gpu_memory_utilization == 0.7
+    assert resolved.vllm_max_num_seqs == 1
+
+    monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 8_000_000_000)
+    resolved = cli._resolve_vllm_settings(settings, model="numind/NuExtract3-W4A16")
     assert resolved.vllm_max_model_len == 8192
     assert resolved.vllm_gpu_memory_utilization == 0.7
     assert resolved.vllm_max_num_seqs == 1

--- a/tests/unit/test_model_profiles.py
+++ b/tests/unit/test_model_profiles.py
@@ -25,6 +25,41 @@ def test_known_model_resolves_platform_memory_tier() -> None:
     assert defaults.max_num_seqs == 4
 
 
+def test_macos_16gib_tier_uses_16k_context() -> None:
+    fallback = RuntimeProfileDefaults(
+        max_model_len=8192,
+        gpu_memory_utilization=0.5,
+        max_num_seqs=1,
+    )
+
+    for memory_bytes in (16 * GIB, 18 * GIB):
+        defaults = runtime_profile_defaults(
+            model="numind/NuExtract3-W4A16",
+            platform=RuntimePlatform.MACOS_APPLE_SILICON,
+            memory_bytes=memory_bytes,
+            fallback=fallback,
+        )
+
+        assert defaults.max_model_len == 16384
+        assert defaults.gpu_memory_utilization == 0.70
+        assert defaults.max_num_seqs == 1
+
+
+def test_macos_below_16gib_keeps_8k_context() -> None:
+    defaults = runtime_profile_defaults(
+        model="numind/NuExtract3-W4A16",
+        platform=RuntimePlatform.MACOS_APPLE_SILICON,
+        memory_bytes=8 * GIB,
+        fallback=RuntimeProfileDefaults(
+            max_model_len=32768,
+            gpu_memory_utilization=0.5,
+            max_num_seqs=4,
+        ),
+    )
+
+    assert defaults.max_model_len == 8192
+
+
 def test_unknown_model_uses_fallback_defaults() -> None:
     defaults = runtime_profile_defaults(
         model="custom/model",


### PR DESCRIPTION
Closes #115

## What

Adds a 16 GiB memory tier to the Apple Silicon runtime profile for `numind/NuExtract3-W4A16`. MacBook Pro machines with 16 or 18 GB of unified memory now start vLLM with `max_model_len=16384` by default instead of falling into the base tier's 8192.

GPU memory utilization (0.70) and `max_num_seqs` (1) stay exactly as they are today for these machines — only the context length changes, since a 16k KV cache for a single sequence fits comfortably within the existing unified-memory budget.

## Verification

Ran on macOS Apple Silicon (MacBook Pro M3 Pro, 18 GB — the exact hardware this issue targets):

- `uv run pytest tests/unit` — 294 passed, 100% coverage
- `parsehawk restart` — runtime log confirms vLLM launched with `max_model_len: 16384, gpu_memory_utilization: 0.7, max_num_seqs: 1` (previous launches on this machine used 8192)
- `just e2e` — 18 passed

Linux NVIDIA was not available for verification; this change only adds a tier to the `MACOS_APPLE_SILICON` profile, so the Linux tiers are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)