### PR TITLE
chore(release): bump version to 0.2.1

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Apache License 2.0
     identifier: Apache-2.0
-  version: 0.2.0
+  version: 0.2.1
 servers:
 - url: http://127.0.0.1:8000
   description: Default local ParseHawk API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parsehawk"
-version = "0.2.0"
+version = "0.2.1"
 description = "Local-first document extraction API."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/tests/unit/server/test_openapi_contract.py
+++ b/tests/unit/server/test_openapi_contract.py
@@ -45,10 +45,10 @@ def _operations() -> list[dict[str, object]]:
 def test_openapi_metadata_is_public_and_versioned() -> None:
     document = app.openapi()
 
-    assert version("parsehawk") == "0.2.0"
+    assert version("parsehawk") == "0.2.1"
     assert document["openapi"] == "3.1.0"
     assert document["info"]["title"] == "ParseHawk API"
-    assert document["info"]["version"] == "0.2.0"
+    assert document["info"]["version"] == "0.2.1"
     assert document["info"]["license"]["identifier"] == "Apache-2.0"
     assert document["servers"] == [
         {

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "parsehawk"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- bump the ParseHawk package metadata and lockfile to `0.2.1`
- regenerate the OpenAPI 3.1 artifact with version `0.2.1`
- update the API contract assertions to enforce the release version

## Why

`v0.2.0` is already published. The runtime reliability improvements and new developer documentation now on `main` should be released together as `v0.2.1`, with one consistent version across the installed package and public API contract.

Follow-up to #123.

## Verification

- `just check`
  - 311 tests passed with the configured 100% coverage gate
  - OpenAPI export sync and structural validation passed
  - Speakeasy lint completed with 0 errors and 0 warnings
  - generated references, developer docs, and internal links passed
  - web typecheck, tests, and production build passed
  - bundled image license checks passed
- all pre-commit hooks passed

Runtime E2E was not rerun because this PR changes release metadata and generated documentation only; it does not change runtime or extraction behavior.
