### PR TITLE
fix(docker): isolate build contexts from host artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,16 +1,24 @@
 .git
-.venv
-.ruff_cache
-.pytest_cache
-.coverage
-.DS_Store
-__pycache__
-*.pyc
+**/.venv
+**/.ruff_cache
+**/.pytest_cache
+**/.coverage
+**/.DS_Store
+**/__pycache__
+**/*.pyc
 
 data
-examples/Testdaten
-node_modules
-apps/web/dist
-apps/web/tsconfig.tsbuildinfo
+examples
+example-applications
+**/node_modules
+**/dist
+**/coverage
+**/*.tsbuildinfo
+**/.cache
+**/playwright-report
+**/test-results
 
-*.log
+**/.env
+**/.env.*
+**/*.env
+**/*.log

--- a/tests/unit/test_dockerignore.py
+++ b/tests/unit/test_dockerignore.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+import pytest
+
+DOCKERIGNORE = Path(__file__).parents[2] / ".dockerignore"
+
+
+def _patterns() -> set[str]:
+    return {
+        line.strip()
+        for line in DOCKERIGNORE.read_text().splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+@pytest.mark.parametrize(
+    "pattern",
+    [
+        "**/.venv",
+        "**/.ruff_cache",
+        "**/.pytest_cache",
+        "**/.coverage",
+        "**/.DS_Store",
+        "**/__pycache__",
+        "**/*.pyc",
+        "**/node_modules",
+        "**/dist",
+        "**/coverage",
+        "**/*.tsbuildinfo",
+        "**/.cache",
+        "**/playwright-report",
+        "**/test-results",
+        "**/.env",
+        "**/.env.*",
+        "**/*.env",
+        "**/*.log",
+    ],
+)
+def test_generated_and_sensitive_artifacts_are_ignored_recursively(pattern: str) -> None:
+    assert pattern in _patterns()
+
+
+@pytest.mark.parametrize("pattern", ["data", "examples", "example-applications"])
+def test_local_runtime_and_example_data_are_ignored(pattern: str) -> None:
+    assert pattern in _patterns()


### PR DESCRIPTION
## Summary

- make generated dependency, cache, metadata, and environment-file exclusions recursive
- exclude local example data, coverage output, and browser test artifacts from Docker contexts
- add regression tests for the recursive and sensitive-path rules

## Root cause

The existing root-only `node_modules` rule did not exclude `apps/web/node_modules`. During the web image build, `COPY apps/web apps/web` overlaid Docker-installed Linux dependencies with host-generated pnpm links and caches. That caused TypeScript to report missing `vitest`, SVG assets, and related types.

The same root-only behavior also admitted nested Python bytecode and macOS metadata. Gitignored local example PDFs added 32.6 MB to the context, while local environment files were not explicitly protected.

## Impact

The web image now builds even when host workspace dependencies are installed. Host caches, bytecode, local data, logs, and environment files no longer enter the shared Docker build context.

The copied context measured 4.3 MB after the fix, down from 38.8 MB in the audited checkout.

## Validation

- Docker-level context inspection found none of the targeted nested artifacts
- `docker compose -f docker/docker-compose.yml build api worker web phoenix`
- `just check`
  - 332 Python tests passed with 100% coverage
  - 34 web tests passed
  - Python and web type checks passed
  - OpenAPI, references, docs build, and link validation passed
  - image license checks passed
- `parsehawk restart`
- `just e2e`: 18 passed on macOS Apple Silicon

Closes #138
