### PR TITLE
feat(runtime): support Linux ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ OpenAI, Microsoft Foundry, or another OpenAI-compatible model server.
 | Platform | Required | Recommended minimum |
 | --- | --- | --- |
 | macOS Apple Silicon | `uv`, Docker Desktop, Xcode Command Line Tools | 16 GB unified memory |
-| Linux x86_64 with NVIDIA | `uv`, Docker Engine + Compose, NVIDIA driver and Container Toolkit | 16 GB VRAM |
+| Linux x86_64 or ARM64 with NVIDIA | `uv`, Docker Engine + Compose, NVIDIA driver and Container Toolkit | 16 GB VRAM |
 
 Windows and Intel Macs are not currently supported for the bundled runtime. You
 can still connect a separately operated provider on a host without a supported

--- a/apps/docs/src/content/docs/how-to/bundled-runtime.md
+++ b/apps/docs/src/content/docs/how-to/bundled-runtime.md
@@ -18,7 +18,7 @@ parsehawk start
 ParseHawk chooses the platform implementation automatically:
 
 - macOS Apple Silicon runs vLLM Metal natively on the host.
-- Linux x86_64 with NVIDIA runs vLLM in Docker Compose.
+- Linux x86_64 or ARM64 with NVIDIA runs vLLM in Docker Compose.
 
 ## Inspect and test the runtime
 

--- a/apps/docs/src/content/docs/how-to/install-linux-nvidia.md
+++ b/apps/docs/src/content/docs/how-to/install-linux-nvidia.md
@@ -32,6 +32,24 @@ uv --version
 Also verify that Docker can expose the GPU to a container using the NVIDIA
 Container Toolkit instructions for your distribution.
 
+ParseHawk also requires the toolkit runtime to be registered with the active
+Docker daemon. Confirm that `nvidia` appears in:
+
+```console
+docker info --format '{{json .Runtimes}}'
+```
+
+If the toolkit is installed but the runtime is missing, configure and verify it:
+
+```console
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+docker info --format '{{json .Runtimes}}'
+```
+
+For rootless Docker, follow NVIDIA's rootless-mode configuration instead of
+modifying the system Docker daemon.
+
 ## Install the CLI
 
 ```console

--- a/apps/docs/src/content/docs/how-to/install-linux-nvidia.md
+++ b/apps/docs/src/content/docs/how-to/install-linux-nvidia.md
@@ -5,12 +5,12 @@ sidebar:
   order: 2
 ---
 
-On Linux x86_64, ParseHawk runs the complete stack in Docker Compose, including
+On Linux x86_64 and ARM64, ParseHawk runs the complete stack in Docker Compose, including
 the vLLM model server.
 
 ## Requirements
 
-- Linux on x86_64
+- Linux on x86_64 or ARM64
 - An NVIDIA GPU with 16 GB VRAM minimum; 24 GB or more for larger contexts
 - NVIDIA driver and NVIDIA Container Toolkit
 - Docker Engine with the Compose plugin

--- a/apps/docs/src/content/docs/reference/runtime-matrix.md
+++ b/apps/docs/src/content/docs/reference/runtime-matrix.md
@@ -10,10 +10,10 @@ sidebar:
 | Host                 | Architecture            | Accelerator            | Runtime location                 | Status             |
 | -------------------- | ----------------------- | ---------------------- | -------------------------------- | ------------------ |
 | macOS                | Apple Silicon (`arm64`) | Metal / unified memory | Host-native vLLM Metal           | Supported          |
-| Linux                | x86_64                  | NVIDIA CUDA            | Docker Compose `runtime` service | Supported          |
+| Linux                | x86_64 or ARM64         | NVIDIA CUDA            | Docker Compose `runtime` service | Supported          |
 | Windows              | —                       | —                      | —                                | Not supported      |
 | macOS Intel          | `x86_64`                | —                      | —                                | Not supported      |
-| Linux without NVIDIA | x86_64                  | CPU or other GPU       | External provider only           | No bundled runtime |
+| Linux without NVIDIA | x86_64 or ARM64         | CPU or other GPU       | External provider only           | No bundled runtime |
 
 The API stack can still use a separately operated provider when the bundled
 runtime is unavailable. Start with `parsehawk start -x runtime`.

--- a/apps/docs/src/content/docs/start-here/choose-installation.md
+++ b/apps/docs/src/content/docs/start-here/choose-installation.md
@@ -8,9 +8,9 @@ sidebar:
 ParseHawk has two supported bundled-runtime paths. Both expose the same Web UI,
 CLI, and REST API.
 
-| Host                     | Bundled model runtime  | Recommended hardware                                            | Setup guide                                       |
-| ------------------------ | ---------------------- | --------------------------------------------------------------- | ------------------------------------------------- |
-| macOS on Apple Silicon   | vLLM Metal on the host | 16 GB unified memory minimum; 32 GB or more for larger contexts | [Install on macOS](/how-to/install-macos/)        |
+| Host                              | Bundled model runtime  | Recommended hardware                                            | Setup guide                                       |
+| --------------------------------- | ---------------------- | --------------------------------------------------------------- | ------------------------------------------------- |
+| macOS on Apple Silicon            | vLLM Metal on the host | 16 GB unified memory minimum; 32 GB or more for larger contexts | [Install on macOS](/how-to/install-macos/)        |
 | Linux x86_64 or ARM64 with NVIDIA | vLLM in Docker Compose | 16 GB VRAM minimum; 24 GB or more for larger contexts           | [Install on Linux](/how-to/install-linux-nvidia/) |
 
 Windows and Intel Macs are not currently supported for the bundled runtime.

--- a/apps/docs/src/content/docs/start-here/choose-installation.md
+++ b/apps/docs/src/content/docs/start-here/choose-installation.md
@@ -11,7 +11,7 @@ CLI, and REST API.
 | Host                     | Bundled model runtime  | Recommended hardware                                            | Setup guide                                       |
 | ------------------------ | ---------------------- | --------------------------------------------------------------- | ------------------------------------------------- |
 | macOS on Apple Silicon   | vLLM Metal on the host | 16 GB unified memory minimum; 32 GB or more for larger contexts | [Install on macOS](/how-to/install-macos/)        |
-| Linux x86_64 with NVIDIA | vLLM in Docker Compose | 16 GB VRAM minimum; 24 GB or more for larger contexts           | [Install on Linux](/how-to/install-linux-nvidia/) |
+| Linux x86_64 or ARM64 with NVIDIA | vLLM in Docker Compose | 16 GB VRAM minimum; 24 GB or more for larger contexts           | [Install on Linux](/how-to/install-linux-nvidia/) |
 
 Windows and Intel Macs are not currently supported for the bundled runtime.
 

--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -122,7 +122,7 @@ def _nvidia_gpu_memory_bytes() -> int | None:
 def _runtime_profile_context() -> tuple[RuntimePlatform, int | None] | None:
     if _is_macos_apple_silicon():
         return RuntimePlatform.MACOS_APPLE_SILICON, _system_memory_bytes()
-    if _is_linux_x86_64():
+    if _is_linux_supported_architecture():
         return RuntimePlatform.LINUX_NVIDIA, _nvidia_gpu_memory_bytes()
     return None
 
@@ -176,8 +176,12 @@ def _is_macos_apple_silicon() -> bool:
     return sys.platform == "darwin" and os.uname().machine == "arm64"
 
 
-def _is_linux_x86_64() -> bool:
-    return sys.platform.startswith("linux") and os.uname().machine == "x86_64"
+def _is_linux_supported_architecture() -> bool:
+    return sys.platform.startswith("linux") and os.uname().machine in {
+        "x86_64",
+        "aarch64",
+        "arm64",
+    }
 
 
 def _vllm_runtime_command(
@@ -808,8 +812,8 @@ def dev(args: argparse.Namespace) -> None:
     if args.runtime == UNSUPPORTED_RUNTIME:
         raise SystemExit(
             "No bundled model runtime is available for this platform. ParseHawk's local "
-            "runtime requires macOS Apple Silicon (vLLM Metal) or Linux x86_64 with an NVIDIA "
-            "GPU (vLLM). Pass --runtime none to start the API without a model runtime."
+            "runtime requires macOS Apple Silicon (vLLM Metal) or Linux x86_64/ARM64 with an "
+            "NVIDIA GPU (vLLM). Pass -x runtime to start the API without a model runtime."
         )
     settings = Settings.from_env()
     config = load_cli_config(apply_env=True)
@@ -902,7 +906,7 @@ def dev(args: argparse.Namespace) -> None:
                 raise SystemExit(
                     "--runtime vllm needs an NVIDIA CUDA GPU, but none was detected "
                     "(nvidia-smi is missing or reported no devices). Run ParseHawk on a "
-                    "Linux x86_64 host with an NVIDIA GPU, or use --runtime none to start "
+                    "Linux x86_64/ARM64 host with an NVIDIA GPU, or use -x runtime to start "
                     "without a model runtime."
                 )
             runtime_cmd[0] = str(
@@ -1020,8 +1024,8 @@ def start_docker(args: argparse.Namespace) -> None:
     if args.runtime == UNSUPPORTED_RUNTIME:
         raise SystemExit(
             "No bundled model runtime is available for this platform. ParseHawk's Docker "
-            "start mode currently supports macOS Apple Silicon and Linux x86_64 with "
-            "an NVIDIA GPU. Pass --runtime none to start without a model runtime."
+            "start mode currently supports macOS Apple Silicon and Linux x86_64/ARM64 with "
+            "an NVIDIA GPU. Pass -x runtime to start without a model runtime."
         )
 
     settings = Settings.from_env()
@@ -1072,7 +1076,7 @@ def start_docker(args: argparse.Namespace) -> None:
     if args.runtime == "vllm":
         if _is_macos_apple_silicon():
             seed_runtime_url = f"http://host.docker.internal:{args.runtime_port}/v1"
-        elif _is_linux_x86_64():
+        elif _is_linux_supported_architecture():
             seed_runtime_url = "http://runtime:8080/v1"
 
     seed_prebuilt_data(
@@ -1125,7 +1129,7 @@ def start_docker(args: argparse.Namespace) -> None:
             )
             processes.append(runtime_process)
             container_runtime_url = f"http://host.docker.internal:{args.runtime_port}/v1"
-        elif _is_linux_x86_64():
+        elif _is_linux_supported_architecture():
             _progress(f"Using Linux vLLM runtime service: {model}")
             container_runtime_url = "http://runtime:8080/v1"
         else:
@@ -1150,7 +1154,7 @@ def start_docker(args: argparse.Namespace) -> None:
     web_enabled = not args.no_web and (web_dir / "package.json").exists()
     if web_enabled:
         services.append("web")
-    if args.runtime == "vllm" and _is_linux_x86_64():
+    if args.runtime == "vllm" and _is_linux_supported_architecture():
         services.insert(0, "runtime")
     compose_profiles: list[str] = []
     if phoenix_enabled:
@@ -1713,7 +1717,7 @@ def _ensure_platform_dependencies(runtime: str) -> None:
     if _is_macos_apple_silicon():
         _ensure_xcode_command_line_tools()
         return
-    if _is_linux_x86_64():
+    if _is_linux_supported_architecture():
         if not _has_nvidia_gpu():
             raise SystemExit(
                 "Linux model runtime requires an NVIDIA GPU and driver, but `nvidia-smi` "
@@ -1725,7 +1729,9 @@ def _ensure_platform_dependencies(runtime: str) -> None:
                 "Container Toolkit and verify `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi`."
             )
         return
-    raise SystemExit("ParseHawk's bundled model runtime supports macOS arm64 or Linux x86_64.")
+    raise SystemExit(
+        "ParseHawk's bundled model runtime supports macOS arm64 or Linux x86_64/ARM64."
+    )
 
 
 def _ensure_xcode_command_line_tools() -> None:
@@ -1780,7 +1786,7 @@ def _compose_project_name(data_dir: Path) -> str:
 def _compose_files(*, runtime: str) -> list[Path]:
     docker_dir = _repo_root() / "docker"
     files = [docker_dir / "docker-compose.yml"]
-    if runtime == "vllm" and _is_linux_x86_64():
+    if runtime == "vllm" and _is_linux_supported_architecture():
         files.append(docker_dir / "docker-compose.linux.yml")
     return files
 

--- a/src/parsehawk/cli/main.py
+++ b/src/parsehawk/cli/main.py
@@ -1724,9 +1724,20 @@ def _ensure_platform_dependencies(runtime: str) -> None:
                 "did not report a usable GPU."
             )
         if not _docker_supports_nvidia_runtime():
+            if shutil.which("nvidia-ctk") is not None:
+                raise SystemExit(
+                    "The NVIDIA Container Toolkit is installed, but Docker does not list the "
+                    "NVIDIA runtime. Configure it for the active Docker daemon, restart Docker, "
+                    "and verify the runtime:\n\n"
+                    "sudo nvidia-ctk runtime configure --runtime=docker\n"
+                    "sudo systemctl restart docker\n"
+                    "docker info --format '{{json .Runtimes}}'"
+                )
             raise SystemExit(
-                "Docker does not appear to expose the NVIDIA runtime. Install the NVIDIA "
-                "Container Toolkit and verify `docker run --rm --gpus all nvidia/cuda:12.4.1-base-ubuntu22.04 nvidia-smi`."
+                "Docker does not list the NVIDIA runtime and `nvidia-ctk` was not found. "
+                "Install the NVIDIA Container Toolkit, configure it with "
+                "`sudo nvidia-ctk runtime configure --runtime=docker`, restart Docker, and "
+                "retry."
             )
         return
     raise SystemExit(
@@ -1775,7 +1786,11 @@ def _docker_supports_nvidia_runtime() -> bool:
         )
     except (OSError, subprocess.SubprocessError):
         return False
-    return "nvidia" in result.stdout
+    try:
+        runtimes = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return False
+    return isinstance(runtimes, dict) and "nvidia" in runtimes
 
 
 def _compose_project_name(data_dir: Path) -> str:

--- a/src/parsehawk/config.py
+++ b/src/parsehawk/config.py
@@ -31,13 +31,13 @@ def default_inference_engine() -> str | None:
 
     Single source of truth shared by the CLI runtime default and the dependency
     markers. Both macOS Apple Silicon and
-    Linux x86_64 use the OpenAI-compatible vLLM runtime contract; macOS reaches
-    that contract through vLLM Metal on the host.
+    Linux x86_64 and ARM64 use the OpenAI-compatible vLLM runtime contract;
+    macOS reaches that contract through vLLM Metal on the host.
     """
     machine = platform.machine()
     if sys.platform == "darwin" and machine == "arm64":
         return "vllm"
-    if sys.platform.startswith("linux") and machine == "x86_64":
+    if sys.platform.startswith("linux") and machine in {"x86_64", "aarch64", "arm64"}:
         return "vllm"
     return None
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -513,7 +513,7 @@ def test_dev_uses_settings_defaults_for_runtime_process(
     monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
     monkeypatch.setenv("PARSEHAWK_VLLM_MODEL", "model-from-env")
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: False)
     monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_ensure_managed_processes_alive", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_wait_for_url", lambda *args, **kwargs: None)
@@ -567,7 +567,7 @@ def test_dev_launches_vllm_runtime_when_selected(
     monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
     monkeypatch.setenv("PARSEHAWK_VLLM_MODEL", "numind/NuExtract3-W4A16")
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 24 * 1024**3)
     monkeypatch.setattr(
@@ -620,6 +620,16 @@ def test_default_runtime_selects_per_platform(monkeypatch: pytest.MonkeyPatch) -
     assert cli._default_runtime() == cli.UNSUPPORTED_RUNTIME
 
 
+@pytest.mark.parametrize("machine", ["x86_64", "aarch64", "arm64"])
+def test_linux_supported_architecture_accepts_x86_and_arm(
+    monkeypatch: pytest.MonkeyPatch, machine: str
+) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+    monkeypatch.setattr(cli.os, "uname", lambda: argparse.Namespace(machine=machine))
+
+    assert cli._is_linux_supported_architecture()
+
+
 def test_vllm_settings_default_to_macos_memory_tier(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -627,7 +637,7 @@ def test_vllm_settings_default_to_macos_memory_tier(
     monkeypatch.delenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION", raising=False)
     monkeypatch.delenv("PARSEHAWK_VLLM_MAX_NUM_SEQS", raising=False)
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: False)
     settings = cli.Settings()
 
     monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 36_000_000_000)
@@ -656,7 +666,7 @@ def test_vllm_settings_default_to_linux_vram_tier(
     monkeypatch.delenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION", raising=False)
     monkeypatch.delenv("PARSEHAWK_VLLM_MAX_NUM_SEQS", raising=False)
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
     settings = cli.Settings()
 
     monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 12 * 1024**3)
@@ -685,7 +695,7 @@ def test_vllm_settings_env_overrides_win(
     monkeypatch.setenv("PARSEHAWK_VLLM_GPU_MEMORY_UTILIZATION", "0.6")
     monkeypatch.setenv("PARSEHAWK_VLLM_MAX_NUM_SEQS", "2")
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: False)
     monkeypatch.setattr(cli, "_system_memory_bytes", lambda: 36_000_000_000)
 
     resolved = cli._resolve_vllm_settings(
@@ -717,7 +727,7 @@ def test_platform_dependencies_macos_checks_xcode(monkeypatch: pytest.MonkeyPatc
     calls: list[str] = []
 
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: False)
     monkeypatch.setattr(cli, "_ensure_xcode_command_line_tools", lambda: calls.append("xcode"))
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: pytest.fail("unexpected GPU check"))
     monkeypatch.setattr(
@@ -735,7 +745,7 @@ def test_platform_dependencies_linux_checks_gpu_and_docker_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cli, "_docker_supports_nvidia_runtime", lambda: True)
     monkeypatch.setattr(
@@ -751,7 +761,7 @@ def test_platform_dependencies_linux_requires_nvidia_docker_runtime(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cli, "_docker_supports_nvidia_runtime", lambda: False)
 
@@ -917,7 +927,7 @@ def test_start_macos_docker_vllm_seeds_container_runtime_provider_url(
 
     monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: True)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: False)
     monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)
     monkeypatch.setattr(cli, "_ensure_platform_dependencies", lambda runtime: None)
@@ -1042,7 +1052,7 @@ def test_start_linux_vllm_uses_internal_runtime_port(
 
     monkeypatch.setenv("PARSEHAWK_DATA_DIR", str(data_dir))
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
-    monkeypatch.setattr(cli, "_is_linux_x86_64", lambda: True)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
     monkeypatch.setattr(cli, "_nvidia_gpu_memory_bytes", lambda: 24 * 1024**3)
     monkeypatch.setattr(cli, "_ensure_start_ports_available", lambda *args, **kwargs: None)
     monkeypatch.setattr(cli, "_ensure_docker_available", lambda: None)

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -757,16 +757,61 @@ def test_platform_dependencies_linux_checks_gpu_and_docker_runtime(
     cli._ensure_platform_dependencies("vllm")
 
 
-def test_platform_dependencies_linux_requires_nvidia_docker_runtime(
+def test_platform_dependencies_linux_requires_nvidia_container_toolkit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
     monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
     monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
     monkeypatch.setattr(cli, "_docker_supports_nvidia_runtime", lambda: False)
+    monkeypatch.setattr(cli.shutil, "which", lambda command: None)
 
-    with pytest.raises(SystemExit, match="NVIDIA Container Toolkit"):
+    with pytest.raises(SystemExit, match="nvidia-ctk.*not found"):
         cli._ensure_platform_dependencies("vllm")
+
+
+def test_platform_dependencies_linux_configures_installed_nvidia_toolkit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(cli, "_is_macos_apple_silicon", lambda: False)
+    monkeypatch.setattr(cli, "_is_linux_supported_architecture", lambda: True)
+    monkeypatch.setattr(cli, "_has_nvidia_gpu", lambda: True)
+    monkeypatch.setattr(cli, "_docker_supports_nvidia_runtime", lambda: False)
+    monkeypatch.setattr(
+        cli.shutil,
+        "which",
+        lambda command: "/usr/bin/nvidia-ctk" if command == "nvidia-ctk" else None,
+    )
+
+    with pytest.raises(SystemExit, match="Toolkit is installed") as error:
+        cli._ensure_platform_dependencies("vllm")
+
+    assert "sudo nvidia-ctk runtime configure --runtime=docker" in str(error.value)
+    assert "sudo systemctl restart docker" in str(error.value)
+    assert "docker info --format '{{json .Runtimes}}'" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    ("docker_info", "expected"),
+    [
+        ('{"io.containerd.runc.v2": {}, "nvidia": {}, "runc": {}}', True),
+        ('{"io.containerd.runc.v2": {}, "runc": {}}', False),
+        ("not-json", False),
+    ],
+)
+def test_docker_supports_nvidia_runtime_parses_registered_runtimes(
+    monkeypatch: pytest.MonkeyPatch, docker_info: str, expected: bool
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda command: "/usr/bin/docker")
+    monkeypatch.setattr(
+        cli.subprocess,
+        "run",
+        lambda *args, **kwargs: cli.subprocess.CompletedProcess(
+            args[0], returncode=0, stdout=docker_info
+        ),
+    )
+
+    assert cli._docker_supports_nvidia_runtime() is expected
 
 
 def test_dev_vllm_without_gpu_exits_with_clear_error(

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from parsehawk import config
+
+
+@pytest.mark.parametrize("machine", ["x86_64", "aarch64", "arm64"])
+def test_default_inference_engine_supports_linux_x86_and_arm(
+    monkeypatch: pytest.MonkeyPatch, machine: str
+) -> None:
+    monkeypatch.setattr(config.sys, "platform", "linux")
+    monkeypatch.setattr(config.platform, "machine", lambda: machine)
+
+    assert config.default_inference_engine() == "vllm"
+
+
+def test_default_inference_engine_rejects_other_linux_architectures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(config.sys, "platform", "linux")
+    monkeypatch.setattr(config.platform, "machine", lambda: "ppc64le")
+
+    assert config.default_inference_engine() is None


### PR DESCRIPTION
## Summary

- enable the bundled Linux NVIDIA runtime on x86_64, aarch64, and arm64
- distinguish an installed NVIDIA Container Toolkit from a Docker daemon that has not registered the NVIDIA runtime
- show the official `nvidia-ctk` configuration and Docker restart commands when registration is missing
- document Linux ARM64 support and the NVIDIA runtime setup across the README, installation guide, bundled-runtime guide, and runtime matrix

## Root cause

Linux runtime selection was restricted to x86_64, even though the existing NVIDIA vLLM configuration can also run on ARM64. The dependency check also treated toolkit installation as sufficient, while Docker must separately register the `nvidia` runtime.

## Verification

- `just check` (343 Python tests, 34 web tests, generated references, docs build, and link validation)
- `parsehawk restart` on Linux x86_64 with an NVIDIA L4
- `just e2e` (18 passed)
- Linux ARM64 startup exercised manually on an NVIDIA DGX Spark

Closes #137