### PR TITLE
chore(release): bump version to 0.2.2

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -12,7 +12,7 @@ info:
   license:
     name: Apache License 2.0
     identifier: Apache-2.0
-  version: 0.2.1
+  version: 0.2.2
 servers:
 - url: http://127.0.0.1:8000
   description: Default local ParseHawk API

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "parsehawk"
-version = "0.2.1"
+version = "0.2.2"
 description = "Local-first document extraction API."
 readme = "README.md"
 requires-python = ">=3.11,<3.13"

--- a/tests/unit/server/test_openapi_contract.py
+++ b/tests/unit/server/test_openapi_contract.py
@@ -45,10 +45,10 @@ def _operations() -> list[dict[str, object]]:
 def test_openapi_metadata_is_public_and_versioned() -> None:
     document = app.openapi()
 
-    assert version("parsehawk") == "0.2.1"
+    assert version("parsehawk") == "0.2.2"
     assert document["openapi"] == "3.1.0"
     assert document["info"]["title"] == "ParseHawk API"
-    assert document["info"]["version"] == "0.2.1"
+    assert document["info"]["version"] == "0.2.2"
     assert document["info"]["license"]["identifier"] == "Apache-2.0"
     assert document["servers"] == [
         {

--- a/uv.lock
+++ b/uv.lock
@@ -713,7 +713,7 @@ wheels = [
 
 [[package]]
 name = "parsehawk"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
## Summary

- bump the ParseHawk package version from `0.2.1` to `0.2.2`
- refresh the lockfile and generated OpenAPI version metadata
- update the public version contract assertions

## Why

The Linux ARM64 runtime support, NVIDIA Docker diagnostics, and Docker build-context reliability improvements merged after v0.2.1 are ready to ship as the v0.2.2 patch release.

## Related issues

Release follow-up for #137 and #138.

## Impact

Package metadata, the generated API contract, and runtime version assertions now consistently report `0.2.2`. There are no additional runtime behavior changes in this PR.

## Validation

- `just check`
- 343 Python tests passed with 100% domain/application coverage
- 34 web tests passed
- OpenAPI validation and generated-reference checks passed
- documentation typecheck, build, artifacts, and internal link validation passed
- web typecheck and production build passed

The optional local OSV scan was skipped because `osv-scanner` is not installed; CI runs it.
