### PR TITLE
fix(persistence): isolate concurrent SQLite work

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,6 +114,7 @@ just lint           # Ruff linting
 just typecheck      # ty type checking
 just test           # Python tests with coverage gate
 just test-unit      # Python unit tests only
+just test-concurrency # SQLite isolation and parallel API regression tests
 just web-typecheck  # TypeScript checks
 just web-test       # Web UI tests
 just web-build      # production Web UI build

--- a/apps/docs/src/content/docs/explanation/architecture.md
+++ b/apps/docs/src/content/docs/explanation/architecture.md
@@ -66,6 +66,11 @@ data/
 The API and worker must see the same database, file store, and provider-secret
 key. Local Docker Compose mounts one host directory into both processes.
 
+Every API use case and worker database phase checks out its own SQLAlchemy Core
+connection and owns one short transaction. Repositories never commit on their
+own. The worker commits its claim before preparing files or calling a model, so
+slow document and provider work never holds a SQLite transaction open.
+
 ## Model boundary
 
 The worker resolves a provider and model for each extractor. All providers use

--- a/apps/docs/src/content/docs/explanation/deployment-hardware.md
+++ b/apps/docs/src/content/docs/explanation/deployment-hardware.md
@@ -54,3 +54,16 @@ The default architecture uses SQLite and a shared local file directory. It is a
 good fit for a single host and local team workflows, not an implicit
 multi-machine control plane. API and worker need consistent access to the same
 database, files, and encryption-key source.
+
+The supported SQLite topology is one API process and one extraction worker
+process on the same host. Concurrent API requests use separate transactions;
+WAL mode lets reads continue during writes, while SQLite still serializes the
+short write phases. If lock contention outlasts the configured internal wait,
+the API returns `503` with code `persistence_busy`, and clients may retry that
+request with backoff.
+
+Multiple Uvicorn worker processes and multiple extraction worker processes are
+not currently a supported deployment topology. They require separate load and
+recovery validation even though the database locking primitives are
+process-safe. Use PostgreSQL rather than a shared SQLite file before scaling the
+control plane across machines.

--- a/apps/docs/src/content/docs/explanation/job-lifecycle.md
+++ b/apps/docs/src/content/docs/explanation/job-lifecycle.md
@@ -52,6 +52,8 @@ canceling job records `deleting`, asks the worker to stop, and removes the recor
 after the worker observes the request.
 
 Clients polling a deleting job should treat a later 404 as successful removal.
+Files and extractors referenced by a job remain protected from deletion until
+the job itself has been removed.
 
 ## Client design
 

--- a/apps/docs/src/content/docs/how-to/jobs.md
+++ b/apps/docs/src/content/docs/how-to/jobs.md
@@ -50,6 +50,10 @@ parsehawk jobs delete job_...
 A queued or terminal job can be removed immediately. A running job first enters
 `deleting` while the worker observes the cancellation request.
 
+A file or extractor referenced by any job cannot be deleted. Delete the job
+explicitly first, then delete its parent resources. This preserves every job ID
+that the API has returned until the client deliberately removes that job.
+
 ## Retry deliberately
 
 Job creation does not currently accept an idempotency key. To avoid duplicates:

--- a/apps/docs/src/content/docs/reference/errors-and-job-states.md
+++ b/apps/docs/src/content/docs/reference/errors-and-job-states.md
@@ -7,16 +7,19 @@ sidebar:
 
 ## API error envelope
 
-Domain and server errors use a `detail` field:
+Domain and server errors use a `detail` field. Actionable or retryable errors
+also include a stable `code`:
 
 ```json
 {
-  "detail": "Human-readable error text"
+  "code": "persistence_busy",
+  "detail": "Persistence is temporarily busy; retry the request"
 }
 ```
 
-FastAPI request-shape validation can return structured validation details in the
-same field. Clients should not assume `detail` is always a string.
+The `code` field is omitted when an error has no machine-readable code. FastAPI
+request-shape validation can return structured validation details in `detail`.
+Clients should not assume `detail` is always a string.
 
 ## Common HTTP statuses
 
@@ -30,6 +33,7 @@ same field. Clients should not assume `detail` is always a string.
 | `404 Not Found`             | Referenced resource does not exist, or asynchronous deletion finished      |
 | `409 Conflict`              | Resource identity conflicts with existing state                            |
 | `422 Unprocessable Content` | Request, schema, or domain input failed validation                         |
+| `503 Service Unavailable`   | SQLite write contention exceeded its wait; retry with backoff              |
 | `500 Internal Server Error` | Unexpected server failure                                                  |
 
 Use the [generated API operation](/reference/api/) for the exact statuses a

--- a/justfile
+++ b/justfile
@@ -32,6 +32,9 @@ test:
 test-unit:
     uv run pytest tests/unit
 
+test-concurrency:
+    uv run pytest --no-cov -m concurrency
+
 e2e:
     uv run pytest --no-cov -m e2e tests/e2e
 

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -37,6 +37,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
   /:
     get:
       tags:
@@ -53,6 +59,12 @@ paths:
                 $ref: '#/components/schemas/RootResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -80,6 +92,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
     post:
       tags:
       - files
@@ -101,6 +119,12 @@ paths:
                 $ref: '#/components/schemas/FileResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -146,6 +170,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '404':
           description: The requested ParseHawk resource does not exist.
           content:
@@ -162,7 +192,8 @@ paths:
       tags:
       - files
       summary: Delete a file
-      description: Delete one stored file and its local content.
+      description: Delete one stored file and its local content. Files referenced by jobs must remain
+        until those jobs are deleted.
       operationId: deleteFile
       parameters:
       - name: file_id
@@ -178,6 +209,12 @@ paths:
           description: Successful Response
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -224,6 +261,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '404':
           description: The requested ParseHawk resource does not exist.
           content:
@@ -264,6 +307,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
     post:
       tags:
       - extractors
@@ -285,6 +334,12 @@ paths:
                 $ref: '#/components/schemas/ExtractorResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -320,6 +375,12 @@ paths:
                 $ref: '#/components/schemas/ExtractorResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -370,6 +431,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '404':
           description: The requested ParseHawk resource does not exist.
           content:
@@ -416,6 +483,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '422':
           description: The request or domain input failed validation.
           content:
@@ -426,7 +499,8 @@ paths:
       tags:
       - extractors
       summary: Delete an extractor
-      description: Delete a custom extractor. Built-in extractors cannot be deleted.
+      description: Delete a custom extractor. Built-in extractors and extractors referenced by jobs cannot
+        be deleted.
       operationId: deleteExtractor
       parameters:
       - name: extractor_ref
@@ -442,6 +516,12 @@ paths:
           description: Successful Response
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -481,6 +561,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
   /v1/providers/{name}:
     get:
       tags:
@@ -505,6 +591,12 @@ paths:
                 $ref: '#/components/schemas/ProviderResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -548,6 +640,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '422':
           description: The request or domain input failed validation.
           content:
@@ -578,6 +676,12 @@ paths:
                 $ref: '#/components/schemas/ProviderModelsResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -616,6 +720,12 @@ paths:
                 $ref: '#/components/schemas/JobResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -681,6 +791,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '422':
           description: Validation Error
           content:
@@ -712,6 +828,12 @@ paths:
                 $ref: '#/components/schemas/JobResponse'
         '500':
           description: Unexpected server error.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
           content:
             application/json:
               schema:
@@ -759,6 +881,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '202':
           description: Cancellation and deletion accepted.
         '404':
@@ -802,6 +930,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '404':
           description: The requested ParseHawk resource does not exist.
           content:
@@ -841,6 +975,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
+        '503':
+          description: Persistence is temporarily busy and the request can be retried.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiErrorResponse'
         '422':
           description: The request or domain input failed validation.
           content:
@@ -854,6 +994,12 @@ components:
   schemas:
     ApiErrorResponse:
       properties:
+        code:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Code
+          description: Stable machine-readable error code when the failure is retryable or actionable.
         detail:
           anyOf:
           - type: string

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -226,11 +226,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiErrorResponse'
         '422':
-          description: Validation Error
+          description: The request or domain input failed validation.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HTTPValidationError'
+                $ref: '#/components/schemas/ApiErrorResponse'
   /v1/files/{file_id}/content:
     get:
       tags:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydantic-settings>=2.14.2",
     "pypdfium2>=5.10.1",
     "python-multipart>=0.0.20",
+    "sqlalchemy>=2.0.0",
     "uvicorn[standard]>=0.32.0",
 ]
 
@@ -64,6 +65,7 @@ select = ["E4", "E7", "E9", "F", "I"]
 addopts = "--cov=parsehawk.core.domain --cov=parsehawk.core.application --cov-report=term-missing --cov-fail-under=100 -m 'not e2e'"
 testpaths = ["tests"]
 markers = [
+    "concurrency: persistence isolation and parallel API regression tests",
     "e2e: local-only API tests; spawn an API+worker on a temp data dir and reuse the running model runtime (run with `just e2e`)",
 ]
 filterwarnings = [

--- a/src/parsehawk/core/application/ports.py
+++ b/src/parsehawk/core/application/ports.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, Iterable, List, Protocol
+from typing import Callable, Iterable, List, Protocol, Self
 
 from parsehawk.core.domain.models import Extractor, File, Job, JobStatus, Provider, ProviderName
 
@@ -64,6 +64,10 @@ class JobRepository(Protocol):  # pragma: no cover
 
     def claim_next_queued(self) -> Job | None: ...
 
+    def has_for_file(self, file_id: str) -> bool: ...
+
+    def has_for_extractor(self, extractor_id: str) -> bool: ...
+
 
 class ProviderRepository(Protocol):  # pragma: no cover
     def save(self, provider: Provider) -> None: ...
@@ -81,6 +85,33 @@ class SecretStore(Protocol):  # pragma: no cover
     def delete(self, provider_name: ProviderName) -> None: ...
 
     def has(self, provider_name: ProviderName) -> bool: ...
+
+
+class UnitOfWork(Protocol):  # pragma: no cover
+    """Application transaction boundary independent of a database toolkit."""
+
+    files: FileRepository
+    extractors: ExtractorRepository
+    jobs: JobRepository
+    providers: ProviderRepository
+    secrets: SecretStore
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> None: ...
+
+    def commit(self) -> None: ...
+
+    def rollback(self) -> None: ...
+
+
+class UnitOfWorkFactory(Protocol):  # pragma: no cover
+    def __call__(self, *, write: bool = False) -> UnitOfWork: ...
 
 
 class FileStorage(Protocol):  # pragma: no cover
@@ -104,7 +135,13 @@ class ExtractionEngine(Protocol):  # pragma: no cover
 class EngineFactory(Protocol):  # pragma: no cover
     def resolve_extractor_config(self, extractor: Extractor) -> ResolvedExecutionConfig: ...
 
-    def for_extractor(self, extractor: Extractor) -> ExtractionEngine: ...
+    def for_extractor(
+        self,
+        extractor: Extractor,
+        *,
+        provider: Provider | None = None,
+        api_key: str | None = None,
+    ) -> ExtractionEngine: ...
 
 
 class ExtractionRequest:

--- a/src/parsehawk/core/application/services.py
+++ b/src/parsehawk/core/application/services.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
+import time
+from collections.abc import Callable
 from dataclasses import asdict
 from enum import StrEnum
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, TypeVar
 
 from jsonschema import Draft202012Validator
 
@@ -46,6 +49,10 @@ from parsehawk.core.domain.models import (
 from parsehawk.core.domain.schemas import MODE_JSON_SCHEMA, validate_extraction_schema
 
 SUPPORTED_FILE_SUFFIXES = {".pdf", ".jpg", ".jpeg", ".png", ".txt", ".md", ".markdown"}
+WORKER_PERSISTENCE_RETRY_DELAY_SECONDS = 0.1
+
+logger = logging.getLogger(__name__)
+ResultT = TypeVar("ResultT")
 
 # The provider new extractors default to when none is specified: the bundled
 # OpenAI-compatible runtime that serves NuExtract3.
@@ -752,8 +759,6 @@ class JobService:
                 return canceled
             return self._get_optional(running.id) or completed
 
-        except PersistenceBusyError:
-            raise
         except ExtractionCancelled as exc:
             canceled = self._cancel_if_requested(running.id)
             if canceled is not None:
@@ -765,28 +770,31 @@ class JobService:
     def _load_execution_state(
         self, job: Job
     ) -> tuple[Extractor, File | None, dict[str, File], Provider | None, str | None]:
-        with self._uow_factory() as uow:
-            extractor = uow.extractors.get(job.extractor_id)
-            if extractor is None:
-                raise NotFoundError("extractor", job.extractor_id)
-            source_file = None
-            if job.file_id is not None:
-                source_file = uow.files.get(job.file_id)
-                if source_file is None:
-                    raise NotFoundError("file", job.file_id)
-            example_files: dict[str, File] = {}
-            for example in extractor.examples:
-                if example.input.type != ExampleInputKind.FILE:
-                    continue
-                assert example.input.file_id is not None
-                example_file = uow.files.get(example.input.file_id)
-                if example_file is None:
-                    raise NotFoundError("file", example.input.file_id)
-                example_files[example_file.id] = example_file
-            resolved_config = self._engine_factory.resolve_extractor_config(extractor)
-            provider = uow.providers.get(resolved_config.provider_name)
-            api_key = uow.secrets.get(resolved_config.provider_name)
-            return extractor, source_file, example_files, provider, api_key
+        def load() -> tuple[Extractor, File | None, dict[str, File], Provider | None, str | None]:
+            with self._uow_factory() as uow:
+                extractor = uow.extractors.get(job.extractor_id)
+                if extractor is None:
+                    raise NotFoundError("extractor", job.extractor_id)
+                source_file = None
+                if job.file_id is not None:
+                    source_file = uow.files.get(job.file_id)
+                    if source_file is None:
+                        raise NotFoundError("file", job.file_id)
+                example_files: dict[str, File] = {}
+                for example in extractor.examples:
+                    if example.input.type != ExampleInputKind.FILE:
+                        continue
+                    assert example.input.file_id is not None
+                    example_file = uow.files.get(example.input.file_id)
+                    if example_file is None:
+                        raise NotFoundError("file", example.input.file_id)
+                    example_files[example_file.id] = example_file
+                resolved_config = self._engine_factory.resolve_extractor_config(extractor)
+                provider = uow.providers.get(resolved_config.provider_name)
+                api_key = uow.secrets.get(resolved_config.provider_name)
+                return extractor, source_file, example_files, provider, api_key
+
+        return self._retry_persistence(load, job_id=job.id, phase="loading execution state")
 
     def _record_failure(self, running: Job, message: str, *, check_cancellation: bool) -> Job:
         failed = running.mark_failed(message)
@@ -799,33 +807,56 @@ class JobService:
         return self._get_optional(running.id) or failed
 
     def _cancel_if_requested(self, job_id: str) -> Job | None:
-        with self._uow_factory(write=True) as uow:
-            latest = uow.jobs.get(job_id)
-            if latest is None:
-                return None
-            if latest.status == JobStatus.CANCELED:
-                return latest
-            if latest.status == JobStatus.DELETING:
-                uow.jobs.delete(latest.id)
-                uow.commit()
-                return latest
-            if latest.status != JobStatus.CANCELING:
-                return None
-            canceled = latest.mark_canceled()
-            if uow.jobs.save_if_status(canceled, [JobStatus.CANCELING]):
-                uow.commit()
-                return canceled
-        return self._get_optional(job_id) or canceled
+        def cancel() -> Job | None:
+            with self._uow_factory(write=True) as uow:
+                latest = uow.jobs.get(job_id)
+                if latest is None:
+                    return None
+                if latest.status == JobStatus.CANCELED:
+                    return latest
+                if latest.status == JobStatus.DELETING:
+                    uow.jobs.delete(latest.id)
+                    uow.commit()
+                    return latest
+                if latest.status != JobStatus.CANCELING:
+                    return None
+                canceled = latest.mark_canceled()
+                if uow.jobs.save_if_status(canceled, [JobStatus.CANCELING]):
+                    uow.commit()
+                    return canceled
+            return self._get_optional(job_id) or canceled
+
+        return self._retry_persistence(cancel, job_id=job_id, phase="applying cancellation")
 
     def _save_if_status(self, job: Job, expected: Iterable[JobStatus]) -> bool:
-        with self._uow_factory(write=True) as uow:
-            saved = uow.jobs.save_if_status(job, expected)
-            uow.commit()
-            return saved
+        def save() -> bool:
+            with self._uow_factory(write=True) as uow:
+                saved = uow.jobs.save_if_status(job, expected)
+                uow.commit()
+                return saved
+
+        return self._retry_persistence(save, job_id=job.id, phase="saving state")
 
     def _get_optional(self, job_id: str) -> Job | None:
-        with self._uow_factory() as uow:
-            return uow.jobs.get(job_id)
+        def get() -> Job | None:
+            with self._uow_factory() as uow:
+                return uow.jobs.get(job_id)
+
+        return self._retry_persistence(get, job_id=job_id, phase="reading state")
+
+    @staticmethod
+    def _retry_persistence(operation: Callable[[], ResultT], *, job_id: str, phase: str) -> ResultT:
+        while True:
+            try:
+                return operation()
+            except PersistenceBusyError:
+                logger.warning(
+                    "Persistence busy while %s for job %s; retrying in %.2f seconds",
+                    phase,
+                    job_id,
+                    WORKER_PERSISTENCE_RETRY_DELAY_SECONDS,
+                )
+                time.sleep(WORKER_PERSISTENCE_RETRY_DELAY_SECONDS)
 
     @staticmethod
     def _get(uow: UnitOfWork, job_id: str) -> Job:

--- a/src/parsehawk/core/application/services.py
+++ b/src/parsehawk/core/application/services.py
@@ -4,22 +4,24 @@ import hashlib
 import os
 from dataclasses import asdict
 from enum import StrEnum
-from typing import Any, List
+from typing import Any, Iterable, List
 
 from jsonschema import Draft202012Validator
 
 from parsehawk.core.application.ports import (
     EngineFactory,
     ExtractionRequest,
-    ExtractorRepository,
-    FileRepository,
     FileStorage,
-    JobRepository,
     PreparedDocument,
-    ProviderRepository,
-    SecretStore,
+    UnitOfWork,
+    UnitOfWorkFactory,
 )
-from parsehawk.core.domain.errors import ExtractionCancelled, NotFoundError, ValidationFailure
+from parsehawk.core.domain.errors import (
+    ExtractionCancelled,
+    NotFoundError,
+    PersistenceBusyError,
+    ValidationFailure,
+)
 from parsehawk.core.domain.ids import new_id
 from parsehawk.core.domain.models import (
     Example,
@@ -66,8 +68,8 @@ class DeleteJobResult(StrEnum):
 
 
 class FileService:
-    def __init__(self, files: FileRepository, storage: FileStorage) -> None:
-        self._files = files
+    def __init__(self, uow_factory: UnitOfWorkFactory, storage: FileStorage) -> None:
+        self._uow_factory = uow_factory
         self._storage = storage
 
     def upload(
@@ -101,37 +103,53 @@ class FileService:
             seed_key=seed_key,
             seed_version=seed_version,
         )
-        self._files.save(file)
+        try:
+            with self._uow_factory(write=True) as uow:
+                uow.files.save(file)
+                uow.commit()
+        except Exception:
+            self._storage.delete_file(file)
+            raise
         return file
 
     def list(self) -> List[File]:
-        return self._files.list()
+        with self._uow_factory() as uow:
+            return uow.files.list()
 
     def get(self, file_id: str) -> File:
-        file = self._files.get(file_id)
+        with self._uow_factory() as uow:
+            return self._get(uow, file_id)
+
+    def delete(self, file_id: str) -> None:
+        with self._uow_factory(write=True) as uow:
+            file = self._get(uow, file_id)
+            if file.is_example:
+                raise ValidationFailure("example files are read-only")
+            if uow.jobs.has_for_file(file_id):
+                raise ValidationFailure(
+                    "file is referenced by jobs; delete those jobs before deleting the file"
+                )
+            uow.files.delete(file_id)
+            uow.commit()
+        self._storage.delete_file(file)
+
+    @staticmethod
+    def _get(uow: UnitOfWork, file_id: str) -> File:
+        file = uow.files.get(file_id)
         if file is None:
             raise NotFoundError("file", file_id)
         return file
-
-    def delete(self, file_id: str) -> None:
-        file = self.get(file_id)
-        if file.is_example:
-            raise ValidationFailure("example files are read-only")
-        self._storage.delete_file(file)
-        self._files.delete(file_id)
 
 
 class ExtractorService:
     def __init__(
         self,
-        extractors: ExtractorRepository,
-        files: FileRepository,
+        uow_factory: UnitOfWorkFactory,
         *,
         default_model: str,
         default_provider: ProviderName = DEFAULT_PROVIDER_NAME,
     ) -> None:
-        self._extractors = extractors
-        self._files = files
+        self._uow_factory = uow_factory
         self._default_model = default_model
         self._default_provider = default_provider
 
@@ -150,18 +168,52 @@ class ExtractorService:
         seed_key: str | None = None,
         seed_version: int | None = None,
     ) -> Extractor:
+        with self._uow_factory(write=True) as uow:
+            extractor = self._create(
+                uow,
+                display_name=display_name,
+                name=name,
+                instructions=instructions,
+                reasoning_effort=reasoning_effort,
+                provider_name=provider_name,
+                model=model,
+                schema=schema,
+                examples=examples,
+                source=source,
+                seed_key=seed_key,
+                seed_version=seed_version,
+            )
+            uow.commit()
+            return extractor
+
+    def _create(
+        self,
+        uow: UnitOfWork,
+        *,
+        display_name: str | None,
+        name: str | None,
+        instructions: str,
+        reasoning_effort: ReasoningEffort | None,
+        provider_name: ProviderName | None,
+        model: str | None,
+        schema: dict[str, Any] | None,
+        examples: List[dict[str, Any]] | None,
+        source: ExtractorSource,
+        seed_key: str | None,
+        seed_version: int | None,
+    ) -> Extractor:
         if display_name is None:
             if name is None:
                 raise ValidationFailure("display_name is required")
             display_name = name
         self._validate_display_name(display_name)
         extractor_id = new_id("extractor")
-        stable_name = name or self._unique_generated_name(display_name, extractor_id)
-        self._validate_new_name(stable_name)
+        stable_name = name or self._unique_generated_name(uow, display_name, extractor_id)
+        self._validate_new_name(uow, stable_name)
         resolved_provider_name = provider_name or self._default_provider
         resolved_model = self._normalize_model(resolved_provider_name, model)
         schema = self._validate_schema(schema)
-        parsed_examples = self._validate_examples(examples or [])
+        parsed_examples = self._validate_examples(uow, examples or [])
         extractor = Extractor(
             id=extractor_id,
             name=stable_name,
@@ -176,23 +228,23 @@ class ExtractorService:
             seed_key=seed_key,
             seed_version=seed_version,
         )
-        self._extractors.save(extractor)
+        uow.extractors.save(extractor)
         return extractor
 
     def list(self) -> List[Extractor]:
-        return self._extractors.list()
+        with self._uow_factory() as uow:
+            return uow.extractors.list()
 
     def get(self, extractor_id: str) -> Extractor:
-        extractor = self._extractors.get(extractor_id)
-        if extractor is None:
-            raise NotFoundError("extractor", extractor_id)
-        return extractor
+        with self._uow_factory() as uow:
+            extractor = uow.extractors.get(extractor_id)
+            if extractor is None:
+                raise NotFoundError("extractor", extractor_id)
+            return extractor
 
     def get_by_ref(self, extractor_ref: str) -> Extractor:
-        extractor = self._resolve_ref(extractor_ref)
-        if extractor is None:
-            raise NotFoundError("extractor", extractor_ref)
-        return extractor
+        with self._uow_factory() as uow:
+            return self._get_by_ref(uow, extractor_ref)
 
     def update(
         self,
@@ -206,30 +258,34 @@ class ExtractorService:
         schema: dict[str, Any] | None = None,
         examples: List[dict[str, Any]] | None = None,
     ) -> Extractor:
-        current = self.get_by_ref(extractor_ref)
-        self._ensure_mutable(current)
-        updates: dict[str, Any] = {"updated_at": utc_now()}
-        if display_name is not None:
-            self._validate_display_name(display_name)
-            updates["display_name"] = display_name
-        if instructions is not None:
-            updates["instructions"] = instructions
-        if not isinstance(reasoning_effort, _NotProvided):
-            updates["reasoning_effort"] = reasoning_effort
-        resolved_provider_name = provider_name or current.provider_name or self._default_provider
-        if provider_name is not None:
-            updates["provider_name"] = provider_name
-        if not isinstance(model, _NotProvided):
-            updates["model"] = self._normalize_model(resolved_provider_name, model)
-        elif provider_name is not None:
-            self._normalize_model(resolved_provider_name, current.model)
-        if schema is not None:
-            updates["schema_"] = self._validate_schema(schema)
-        if examples is not None:
-            updates["examples"] = self._validate_examples(examples)
-        updated = current.model_copy(update=updates)
-        self._extractors.save(updated)
-        return updated
+        with self._uow_factory(write=True) as uow:
+            current = self._get_by_ref(uow, extractor_ref)
+            self._ensure_mutable(current)
+            updates: dict[str, Any] = {"updated_at": utc_now()}
+            if display_name is not None:
+                self._validate_display_name(display_name)
+                updates["display_name"] = display_name
+            if instructions is not None:
+                updates["instructions"] = instructions
+            if not isinstance(reasoning_effort, _NotProvided):
+                updates["reasoning_effort"] = reasoning_effort
+            resolved_provider_name = (
+                provider_name or current.provider_name or self._default_provider
+            )
+            if provider_name is not None:
+                updates["provider_name"] = provider_name
+            if not isinstance(model, _NotProvided):
+                updates["model"] = self._normalize_model(resolved_provider_name, model)
+            elif provider_name is not None:
+                self._normalize_model(resolved_provider_name, current.model)
+            if schema is not None:
+                updates["schema_"] = self._validate_schema(schema)
+            if examples is not None:
+                updates["examples"] = self._validate_examples(uow, examples)
+            updated = current.model_copy(update=updates)
+            uow.extractors.save(updated)
+            uow.commit()
+            return updated
 
     def upsert(
         self,
@@ -244,42 +300,62 @@ class ExtractorService:
         schema: dict[str, Any] | None = None,
         examples: List[dict[str, Any]] | None = None,
     ) -> Extractor:
-        existing = self._resolve_ref(extractor_ref)
-        if existing is not None:
-            self._ensure_mutable(existing)
-            if body_name is not None and body_name != existing.name:
-                raise ValidationFailure("request body name must match the target extractor name")
-            return self._replace(
-                existing,
-                display_name=display_name,
-                instructions=instructions,
-                reasoning_effort=reasoning_effort,
-                provider_name=provider_name,
-                model=model,
-                schema=schema,
-                examples=examples,
-            )
-        self._validate_new_name(extractor_ref)
-        if body_name is not None and body_name != extractor_ref:
-            raise ValidationFailure("request body name must match the target extractor name")
-        return self.create(
-            name=extractor_ref,
-            display_name=display_name,
-            instructions=instructions,
-            reasoning_effort=reasoning_effort,
-            provider_name=provider_name,
-            model=model,
-            schema=schema,
-            examples=examples,
-        )
+        with self._uow_factory(write=True) as uow:
+            existing = self._resolve_ref(uow, extractor_ref)
+            if existing is not None:
+                self._ensure_mutable(existing)
+                if body_name is not None and body_name != existing.name:
+                    raise ValidationFailure(
+                        "request body name must match the target extractor name"
+                    )
+                extractor = self._replace(
+                    uow,
+                    existing,
+                    display_name=display_name,
+                    instructions=instructions,
+                    reasoning_effort=reasoning_effort,
+                    provider_name=provider_name,
+                    model=model,
+                    schema=schema,
+                    examples=examples,
+                )
+            else:
+                self._validate_new_name(uow, extractor_ref)
+                if body_name is not None and body_name != extractor_ref:
+                    raise ValidationFailure(
+                        "request body name must match the target extractor name"
+                    )
+                extractor = self._create(
+                    uow,
+                    name=extractor_ref,
+                    display_name=display_name,
+                    instructions=instructions,
+                    reasoning_effort=reasoning_effort,
+                    provider_name=provider_name,
+                    model=model,
+                    schema=schema,
+                    examples=examples,
+                    source=ExtractorSource.USER,
+                    seed_key=None,
+                    seed_version=None,
+                )
+            uow.commit()
+            return extractor
 
     def delete(self, extractor_ref: str) -> None:
-        extractor = self.get_by_ref(extractor_ref)
-        self._ensure_mutable(extractor)
-        self._extractors.delete(extractor.id)
+        with self._uow_factory(write=True) as uow:
+            extractor = self._get_by_ref(uow, extractor_ref)
+            self._ensure_mutable(extractor)
+            if uow.jobs.has_for_extractor(extractor.id):
+                raise ValidationFailure(
+                    "extractor is referenced by jobs; delete those jobs before deleting the extractor"
+                )
+            uow.extractors.delete(extractor.id)
+            uow.commit()
 
     def _replace(
         self,
+        uow: UnitOfWork,
         current: Extractor,
         *,
         display_name: str,
@@ -301,11 +377,11 @@ class ExtractorService:
                 "provider_name": resolved_provider_name,
                 "model": resolved_model,
                 "schema_": self._validate_schema(schema),
-                "examples": self._validate_examples(examples or []),
+                "examples": self._validate_examples(uow, examples or []),
                 "updated_at": utc_now(),
             }
         )
-        self._extractors.save(updated)
+        uow.extractors.save(updated)
         return updated
 
     def _normalize_model(self, provider_name: ProviderName, model: str | None) -> str | None:
@@ -316,27 +392,35 @@ class ExtractorService:
             raise ValidationFailure(f"model is required for provider {provider_name.value}")
         return normalized
 
-    def _resolve_ref(self, extractor_ref: str) -> Extractor | None:
-        return self._extractors.get(extractor_ref) or self._extractors.get_by_name(extractor_ref)
+    @staticmethod
+    def _resolve_ref(uow: UnitOfWork, extractor_ref: str) -> Extractor | None:
+        return uow.extractors.get(extractor_ref) or uow.extractors.get_by_name(extractor_ref)
 
-    def _unique_generated_name(self, display_name: str, extractor_id: str) -> str:
+    def _get_by_ref(self, uow: UnitOfWork, extractor_ref: str) -> Extractor:
+        extractor = self._resolve_ref(uow, extractor_ref)
+        if extractor is None:
+            raise NotFoundError("extractor", extractor_ref)
+        return extractor
+
+    def _unique_generated_name(self, uow: UnitOfWork, display_name: str, extractor_id: str) -> str:
         base = slugify_extractor_name(display_name)
-        if self._extractors.get_by_name(base) is None:
+        if uow.extractors.get_by_name(base) is None:
             return base
         for suffix_length in (8, 10, 12, 16, 32):
             suffix = extractor_name_suffix(extractor_id, suffix_length)
             max_base_len = 64 - len(suffix) - 1
             candidate = f"{base[:max_base_len].rstrip('-_')}-{suffix}"
-            if self._extractors.get_by_name(candidate) is None:
+            if uow.extractors.get_by_name(candidate) is None:
                 return candidate
         raise ValidationFailure("could not generate a unique extractor name")
 
-    def _validate_new_name(self, name: str) -> None:
+    @staticmethod
+    def _validate_new_name(uow: UnitOfWork, name: str) -> None:
         try:
             validate_extractor_name(name)
         except ValueError as exc:
             raise ValidationFailure(str(exc)) from exc
-        existing = self._extractors.get_by_name(name)
+        existing = uow.extractors.get_by_name(name)
         if existing is not None:
             raise ValidationFailure(f"extractor name already exists: {name}")
 
@@ -366,13 +450,14 @@ class ExtractorService:
         assert result.json_schema is not None
         return result.json_schema
 
-    def _validate_examples(self, examples: List[dict[str, Any]]) -> List[Example]:
+    @staticmethod
+    def _validate_examples(uow: UnitOfWork, examples: List[dict[str, Any]]) -> List[Example]:
         parsed_examples = [Example.model_validate(example) for example in examples]
         for example in parsed_examples:
             if example.input.type != ExampleInputKind.FILE:
                 continue
             assert example.input.file_id is not None
-            if self._files.get(example.input.file_id) is None:
+            if uow.files.get(example.input.file_id) is None:
                 raise NotFoundError("file", example.input.file_id)
         return parsed_examples
 
@@ -385,21 +470,48 @@ class ProviderService:
     them; they are never returned.
     """
 
-    def __init__(self, providers: ProviderRepository, secrets: SecretStore) -> None:
-        self._providers = providers
-        self._secrets = secrets
+    def __init__(self, uow_factory: UnitOfWorkFactory) -> None:
+        self._uow_factory = uow_factory
 
     def list(self) -> List[Provider]:
-        return self._providers.list()
+        with self._uow_factory() as uow:
+            return uow.providers.list()
 
     def get(self, name: ProviderName) -> Provider:
-        provider = self._providers.get(name)
-        if provider is None:
-            raise NotFoundError("provider", name.value)
-        return provider
+        with self._uow_factory() as uow:
+            return self._get(uow, name)
 
     def has_api_key(self, name: ProviderName) -> bool:
-        return self._secrets.has(name)
+        with self._uow_factory() as uow:
+            return uow.secrets.has(name)
+
+    def get_with_api_key(self, name: ProviderName) -> tuple[Provider, str | None]:
+        with self._uow_factory() as uow:
+            return self._get(uow, name), uow.secrets.get(name)
+
+    def ensure(
+        self,
+        provider: Provider,
+        *,
+        replace_base_url_if: frozenset[str | None] = frozenset(),
+    ) -> Provider:
+        """Create a fixed provider or reconcile a known generated base URL."""
+        with self._uow_factory(write=True) as uow:
+            existing = uow.providers.get(provider.name)
+            if existing is None:
+                resolved = provider
+                uow.providers.save(resolved)
+            elif (
+                existing.base_url != provider.base_url and existing.base_url in replace_base_url_if
+            ):
+                resolved = existing.model_copy(
+                    update={"base_url": provider.base_url, "updated_at": utc_now()}
+                )
+                uow.providers.save(resolved)
+            else:
+                resolved = existing
+            uow.commit()
+            return resolved
 
     def configure(
         self,
@@ -410,20 +522,29 @@ class ProviderService:
         api_key: str | None = None,
         api_key_env: str | None = None,
     ) -> Provider:
-        provider = self.get(name)
-        updates: dict[str, Any] = {}
-        if base_url is not None:
-            updates["base_url"] = base_url
-        if configuration is not None:
-            updates["configuration"] = normalize_provider_configuration(name, configuration)
-        if updates:
-            provider = Provider.model_validate(
-                {**provider.model_dump(), **updates, "updated_at": utc_now()}
-            )
-            self._providers.save(provider)
         resolved_key = self._resolve_api_key(api_key, api_key_env)
-        if resolved_key is not None:
-            self._secrets.put(name, resolved_key)
+        with self._uow_factory(write=True) as uow:
+            provider = self._get(uow, name)
+            updates: dict[str, Any] = {}
+            if base_url is not None:
+                updates["base_url"] = base_url
+            if configuration is not None:
+                updates["configuration"] = normalize_provider_configuration(name, configuration)
+            if updates:
+                provider = Provider.model_validate(
+                    {**provider.model_dump(), **updates, "updated_at": utc_now()}
+                )
+                uow.providers.save(provider)
+            if resolved_key is not None:
+                uow.secrets.put(name, resolved_key)
+            uow.commit()
+            return provider
+
+    @staticmethod
+    def _get(uow: UnitOfWork, name: ProviderName) -> Provider:
+        provider = uow.providers.get(name)
+        if provider is None:
+            raise NotFoundError("provider", name.value)
         return provider
 
     @staticmethod
@@ -441,15 +562,11 @@ class ProviderService:
 class JobService:
     def __init__(
         self,
-        jobs: JobRepository,
-        files: FileRepository,
-        extractors: ExtractorRepository,
+        uow_factory: UnitOfWorkFactory,
         storage: FileStorage,
         engine_factory: EngineFactory,
     ) -> None:
-        self._jobs = jobs
-        self._files = files
-        self._extractors = extractors
+        self._uow_factory = uow_factory
         self._storage = storage
         self._engine_factory = engine_factory
 
@@ -464,127 +581,137 @@ class JobService:
         provided_extractors = [extractor_id is not None, extractor_name is not None]
         if provided_extractors.count(True) != 1:
             raise ValidationFailure("provide exactly one of extractor_id or extractor_name")
-        extractor = (
-            self._extractors.get(extractor_id)
-            if extractor_id is not None
-            else self._extractors.get_by_name(extractor_name or "")
-        )
-        if extractor is None:
-            raise NotFoundError("extractor", extractor_id or extractor_name or "")
         provided_inputs = [file_id is not None, text is not None]
         if provided_inputs.count(True) != 1:
             raise ValidationFailure("provide exactly one of file_id or text")
-        if file_id is not None and self._files.get(file_id) is None:
-            raise NotFoundError("file", file_id)
         if text is not None and not text.strip():
             raise ValidationFailure("text input cannot be empty")
-        job_id = new_id("job")
-        job = Job(
-            id=job_id,
-            extractor_id=extractor.id,
-            file_id=file_id,
-            source_text=text,
-            status=JobStatus.QUEUED,
-        )
-        self._jobs.save(job)
-        return job
+
+        with self._uow_factory(write=True) as uow:
+            extractor = (
+                uow.extractors.get(extractor_id)
+                if extractor_id is not None
+                else uow.extractors.get_by_name(extractor_name or "")
+            )
+            if extractor is None:
+                raise NotFoundError("extractor", extractor_id or extractor_name or "")
+            if file_id is not None and uow.files.get(file_id) is None:
+                raise NotFoundError("file", file_id)
+            job = Job(
+                id=new_id("job"),
+                extractor_id=extractor.id,
+                file_id=file_id,
+                source_text=text,
+                status=JobStatus.QUEUED,
+            )
+            uow.jobs.save(job)
+            uow.commit()
+            return job
 
     def list(self, extractor_id: str | None = None, extractor_name: str | None = None) -> List[Job]:
         provided_extractors = [extractor_id is not None, extractor_name is not None]
         if provided_extractors.count(True) > 1:
             raise ValidationFailure("provide only one of extractor_id or extractor_name")
-        if extractor_id is None and extractor_name is None:
-            return self._jobs.list()
-        extractor = (
-            self._extractors.get(extractor_id)
-            if extractor_id is not None
-            else self._extractors.get_by_name(extractor_name or "")
-        )
-        if extractor is None:
-            raise NotFoundError("extractor", extractor_id or extractor_name or "")
-        return self._jobs.list(extractor_id=extractor.id)
+        with self._uow_factory() as uow:
+            if extractor_id is None and extractor_name is None:
+                return uow.jobs.list()
+            extractor = (
+                uow.extractors.get(extractor_id)
+                if extractor_id is not None
+                else uow.extractors.get_by_name(extractor_name or "")
+            )
+            if extractor is None:
+                raise NotFoundError("extractor", extractor_id or extractor_name or "")
+            return uow.jobs.list(extractor_id=extractor.id)
 
     def get(self, job_id: str) -> Job:
-        job = self._jobs.get(job_id)
-        if job is None:
-            raise NotFoundError("job", job_id)
-        return job
+        with self._uow_factory() as uow:
+            return self._get(uow, job_id)
 
     def cancel(self, job_id: str) -> Job:
-        job = self.get(job_id)
-
-        if job.status == JobStatus.QUEUED:
-            canceled = job.mark_canceled()
-            if self._jobs.save_if_status(canceled, [JobStatus.QUEUED]):
-                return canceled
-        elif job.status == JobStatus.RUNNING:
-            canceling = job.mark_canceling()
-            if self._jobs.save_if_status(canceling, [JobStatus.RUNNING]):
-                return canceling
-        else:
-            raise ValidationFailure(f"cannot cancel job in '{job.status.value}' state")
-
-        return self.cancel(job_id)
+        while True:
+            with self._uow_factory(write=True) as uow:
+                job = self._get(uow, job_id)
+                if job.status == JobStatus.QUEUED:
+                    next_job = job.mark_canceled()
+                    expected = [JobStatus.QUEUED]
+                elif job.status == JobStatus.RUNNING:
+                    next_job = job.mark_canceling()
+                    expected = [JobStatus.RUNNING]
+                else:
+                    raise ValidationFailure(f"cannot cancel job in '{job.status.value}' state")
+                saved = uow.jobs.save_if_status(next_job, expected)
+                if saved:
+                    uow.commit()
+                    return next_job
 
     def delete(self, job_id: str) -> DeleteJobResult:
-        job = self.get(job_id)
-
-        if job.status in {
-            JobStatus.QUEUED,
-            JobStatus.COMPLETED,
-            JobStatus.FAILED,
-            JobStatus.CANCELED,
-        }:
-            if self._jobs.delete_if_status(job_id, [job.status]):
-                return DeleteJobResult.DELETED
-        elif job.status == JobStatus.RUNNING:
-            if self._jobs.save_if_status(job.mark_deleting(), [JobStatus.RUNNING]):
-                return DeleteJobResult.ACCEPTED
-        elif job.status == JobStatus.CANCELING:
-            if self._jobs.save_if_status(job.mark_deleting(), [JobStatus.CANCELING]):
-                return DeleteJobResult.ACCEPTED
-        elif job.status == JobStatus.DELETING:
-            return DeleteJobResult.ACCEPTED
-
-        return self.delete(job_id)
+        while True:
+            with self._uow_factory(write=True) as uow:
+                job = self._get(uow, job_id)
+                if job.status in {
+                    JobStatus.QUEUED,
+                    JobStatus.COMPLETED,
+                    JobStatus.FAILED,
+                    JobStatus.CANCELED,
+                }:
+                    changed = uow.jobs.delete_if_status(job_id, [job.status])
+                    result = DeleteJobResult.DELETED
+                elif job.status in {JobStatus.RUNNING, JobStatus.CANCELING}:
+                    changed = uow.jobs.save_if_status(job.mark_deleting(), [job.status])
+                    result = DeleteJobResult.ACCEPTED
+                elif job.status == JobStatus.DELETING:
+                    return DeleteJobResult.ACCEPTED
+                else:  # pragma: no cover - JobStatus is exhaustively handled above
+                    raise ValidationFailure(f"cannot delete job in '{job.status.value}' state")
+                if changed:
+                    uow.commit()
+                    return result
 
     def run_next_queued(self) -> Job | None:
-        claimed = self._jobs.claim_next_queued()
+        with self._uow_factory(write=True) as uow:
+            claimed = uow.jobs.claim_next_queued()
+            uow.commit()
         if claimed is None:
             return None
         return self.run_claimed(claimed)
 
     def run_claimed(self, job: Job) -> Job:
         running = job if job.status == JobStatus.RUNNING else job.mark_running()
-        if job.status != JobStatus.RUNNING and not self._jobs.save_if_status(running, [job.status]):
+        if job.status != JobStatus.RUNNING and not self._save_if_status(running, [job.status]):
             canceled = self._cancel_if_requested(running.id)
             if canceled is not None:
                 return canceled
-            latest = self._jobs.get(running.id)
+            latest = self._get_optional(running.id)
             if latest is not None:
                 return latest
         try:
-            extractor = self._extractors.get(running.extractor_id)
-            if extractor is None:
-                raise NotFoundError("extractor", running.extractor_id)
+            extractor, source_file, example_files, provider, api_key = self._load_execution_state(
+                running
+            )
             resolved_config = self._engine_factory.resolve_extractor_config(extractor)
             running = running.with_execution_config(
                 provider_name=resolved_config.provider_name,
                 model=resolved_config.model,
             )
-            if not self._jobs.save_if_status(running, [JobStatus.RUNNING]):
+            if not self._save_if_status(running, [JobStatus.RUNNING]):
                 canceled = self._cancel_if_requested(running.id)
                 if canceled is not None:
                     return canceled
-                latest = self._jobs.get(running.id)
+                latest = self._get_optional(running.id)
                 if latest is not None:
                     return latest
-            source = self._prepare_job_source(running)
 
-            engine = self._engine_factory.for_extractor(extractor)
+            source = self._prepare_job_source(running, source_file)
+            examples = self._resolve_examples(extractor, example_files)
+            engine = self._engine_factory.for_extractor(
+                extractor,
+                provider=provider,
+                api_key=api_key,
+            )
 
             def cancellation_requested() -> bool:
-                latest = self._jobs.get(running.id)
+                latest = self._get_optional(running.id)
                 return latest is not None and latest.status in {
                     JobStatus.CANCELING,
                     JobStatus.DELETING,
@@ -602,15 +729,12 @@ class JobService:
                     instructions=extractor.instructions,
                     reasoning_effort=extractor.reasoning_effort,
                     schema=extractor.schema,
-                    examples=self._resolve_examples(extractor),
+                    examples=examples,
                 ),
                 cancellation_check=cancellation_requested,
             )
             validation_errors = self._validate_output(extractor.schema, response.data)
-            result = JobResult(
-                data=response.data,
-                validation_errors=validation_errors,
-            )
+            result = JobResult(data=response.data, validation_errors=validation_errors)
             completed = (
                 running.mark_completed(result)
                 if result.valid
@@ -621,50 +745,94 @@ class JobService:
             canceled = self._cancel_if_requested(running.id)
             if canceled is not None:
                 return canceled
-
-            if self._jobs.save_if_status(completed, [JobStatus.RUNNING]):
+            if self._save_if_status(completed, [JobStatus.RUNNING]):
                 return completed
             canceled = self._cancel_if_requested(running.id)
             if canceled is not None:
                 return canceled
-            latest = self._jobs.get(running.id)
-            return latest if latest is not None else completed
+            return self._get_optional(running.id) or completed
 
+        except PersistenceBusyError:
+            raise
         except ExtractionCancelled as exc:
             canceled = self._cancel_if_requested(running.id)
             if canceled is not None:
                 return canceled
-            failed = running.mark_failed(str(exc))
-            if self._jobs.save_if_status(failed, [JobStatus.RUNNING]):
-                return failed
-            latest = self._jobs.get(running.id)
-            return latest if latest is not None else failed
-
+            return self._record_failure(running, str(exc), check_cancellation=False)
         except Exception as exc:
-            failed = running.mark_failed(str(exc))
-            if self._jobs.save_if_status(failed, [JobStatus.RUNNING]):
-                return failed
+            return self._record_failure(running, str(exc), check_cancellation=True)
+
+    def _load_execution_state(
+        self, job: Job
+    ) -> tuple[Extractor, File | None, dict[str, File], Provider | None, str | None]:
+        with self._uow_factory() as uow:
+            extractor = uow.extractors.get(job.extractor_id)
+            if extractor is None:
+                raise NotFoundError("extractor", job.extractor_id)
+            source_file = None
+            if job.file_id is not None:
+                source_file = uow.files.get(job.file_id)
+                if source_file is None:
+                    raise NotFoundError("file", job.file_id)
+            example_files: dict[str, File] = {}
+            for example in extractor.examples:
+                if example.input.type != ExampleInputKind.FILE:
+                    continue
+                assert example.input.file_id is not None
+                example_file = uow.files.get(example.input.file_id)
+                if example_file is None:
+                    raise NotFoundError("file", example.input.file_id)
+                example_files[example_file.id] = example_file
+            resolved_config = self._engine_factory.resolve_extractor_config(extractor)
+            provider = uow.providers.get(resolved_config.provider_name)
+            api_key = uow.secrets.get(resolved_config.provider_name)
+            return extractor, source_file, example_files, provider, api_key
+
+    def _record_failure(self, running: Job, message: str, *, check_cancellation: bool) -> Job:
+        failed = running.mark_failed(message)
+        if self._save_if_status(failed, [JobStatus.RUNNING]):
+            return failed
+        if check_cancellation:
             canceled = self._cancel_if_requested(running.id)
             if canceled is not None:
                 return canceled
-            latest = self._jobs.get(running.id)
-            return latest if latest is not None else failed
+        return self._get_optional(running.id) or failed
 
     def _cancel_if_requested(self, job_id: str) -> Job | None:
-        latest = self._jobs.get(job_id)
-        if latest is None:
-            return None
-        if latest.status == JobStatus.CANCELED:
-            return latest
-        if latest.status == JobStatus.DELETING:
-            self._jobs.delete(latest.id)
-            return latest
-        if latest.status != JobStatus.CANCELING:
-            return None
-        canceled = latest.mark_canceled()
-        if self._jobs.save_if_status(canceled, [JobStatus.CANCELING]):
-            return canceled
-        return self._jobs.get(job_id) or canceled
+        with self._uow_factory(write=True) as uow:
+            latest = uow.jobs.get(job_id)
+            if latest is None:
+                return None
+            if latest.status == JobStatus.CANCELED:
+                return latest
+            if latest.status == JobStatus.DELETING:
+                uow.jobs.delete(latest.id)
+                uow.commit()
+                return latest
+            if latest.status != JobStatus.CANCELING:
+                return None
+            canceled = latest.mark_canceled()
+            if uow.jobs.save_if_status(canceled, [JobStatus.CANCELING]):
+                uow.commit()
+                return canceled
+        return self._get_optional(job_id) or canceled
+
+    def _save_if_status(self, job: Job, expected: Iterable[JobStatus]) -> bool:
+        with self._uow_factory(write=True) as uow:
+            saved = uow.jobs.save_if_status(job, expected)
+            uow.commit()
+            return saved
+
+    def _get_optional(self, job_id: str) -> Job | None:
+        with self._uow_factory() as uow:
+            return uow.jobs.get(job_id)
+
+    @staticmethod
+    def _get(uow: UnitOfWork, job_id: str) -> Job:
+        job = uow.jobs.get(job_id)
+        if job is None:
+            raise NotFoundError("job", job_id)
+        return job
 
     @staticmethod
     def _validate_output(schema: dict[str, Any], data: dict[str, Any]) -> List[ValidationIssue]:
@@ -675,11 +843,9 @@ class JobService:
             issues.append(ValidationIssue(path=path or "$", message=error.message))
         return issues
 
-    def _prepare_job_source(self, job: Job) -> PreparedDocument:
+    def _prepare_job_source(self, job: Job, file: File | None) -> PreparedDocument:
         if job.file_id is not None:
-            file = self._files.get(job.file_id)
-            if file is None:
-                raise NotFoundError("file", job.file_id)
+            assert file is not None
             return self._storage.prepare_document(file)
         assert job.source_text is not None
         return PreparedDocument(
@@ -689,7 +855,9 @@ class JobService:
             images=[],
         )
 
-    def _resolve_examples(self, extractor: Extractor) -> List[dict[str, Any]]:
+    def _resolve_examples(
+        self, extractor: Extractor, example_files: dict[str, File]
+    ) -> List[dict[str, Any]]:
         resolved_examples: List[dict[str, Any]] = []
         for example in extractor.examples:
             if example.input.type == ExampleInputKind.TEXT:
@@ -700,8 +868,8 @@ class JobService:
                 }
             else:
                 assert example.input.file_id is not None
-                file = self._files.get(example.input.file_id)
-                if file is None:
+                file = example_files.get(example.input.file_id)
+                if file is None:  # pragma: no cover - execution state preloads every file
                     raise NotFoundError("file", example.input.file_id)
                 document = self._storage.prepare_document(file)
                 example_input = {

--- a/src/parsehawk/core/application/services.py
+++ b/src/parsehawk/core/application/services.py
@@ -136,9 +136,11 @@ class FileService:
                 raise ValidationFailure(
                     "file is referenced by jobs; delete those jobs before deleting the file"
                 )
+            # Local deletion is idempotent. Keep the write transaction open so a
+            # storage failure leaves the metadata and parent check retryable.
+            self._storage.delete_file(file)
             uow.files.delete(file_id)
             uow.commit()
-        self._storage.delete_file(file)
 
     @staticmethod
     def _get(uow: UnitOfWork, file_id: str) -> File:

--- a/src/parsehawk/core/domain/errors.py
+++ b/src/parsehawk/core/domain/errors.py
@@ -27,3 +27,13 @@ class ProviderRequestError(ParseHawkError):
     def __init__(self, message: str, *, status_code: int | None = None) -> None:
         super().__init__(message)
         self.status_code = status_code
+
+
+class PersistenceBusyError(ParseHawkError):
+    """Raised when persistence lock contention exceeds the configured wait."""
+
+    code = "persistence_busy"
+    retryable = True
+
+    def __init__(self) -> None:
+        super().__init__("Persistence is temporarily busy; retry the request")

--- a/src/parsehawk/server/adapters/persistence/migrations/20260721120000_restrict_job_parent_deletion.sql
+++ b/src/parsehawk/server/adapters/persistence/migrations/20260721120000_restrict_job_parent_deletion.sql
@@ -1,0 +1,32 @@
+-- Preserve accepted job history when its referenced file or extractor is deleted.
+-- Parent resources must now remain until their jobs are explicitly removed.
+
+CREATE TABLE jobs_new (
+    id TEXT PRIMARY KEY,
+    extractor_id TEXT NOT NULL REFERENCES extractors(id) ON DELETE RESTRICT,
+    file_id TEXT REFERENCES files(id) ON DELETE RESTRICT,
+    source_text TEXT,
+    status TEXT NOT NULL,
+    result TEXT,
+    error TEXT,
+    created_at TEXT NOT NULL,
+    started_at TEXT,
+    completed_at TEXT,
+    provider_name_used TEXT,
+    model_used TEXT
+);
+
+INSERT INTO jobs_new (
+    id, extractor_id, file_id, source_text, status, result, error,
+    created_at, started_at, completed_at, provider_name_used, model_used
+)
+SELECT
+    id, extractor_id, file_id, source_text, status, result, error,
+    created_at, started_at, completed_at, provider_name_used, model_used
+FROM jobs;
+
+DROP TABLE jobs;
+ALTER TABLE jobs_new RENAME TO jobs;
+
+CREATE INDEX idx_jobs_extractor_id ON jobs(extractor_id);
+CREATE INDEX idx_jobs_status_created_at ON jobs(status, created_at);

--- a/src/parsehawk/server/adapters/persistence/sqlite.py
+++ b/src/parsehawk/server/adapters/persistence/sqlite.py
@@ -2,12 +2,25 @@ from __future__ import annotations
 
 import json
 import sqlite3
-import threading
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Iterable, List
+from typing import Any, Iterable, List, cast
 
+from sqlalchemy import Connection, Engine, create_engine, delete, event, select, update
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.engine import URL, RowMapping
+from sqlalchemy.exc import DBAPIError
+
+from parsehawk.core.application.ports import (
+    ExtractorRepository,
+    FileRepository,
+    JobRepository,
+    ProviderRepository,
+    SecretStore,
+    UnitOfWork,
+)
+from parsehawk.core.domain.errors import PersistenceBusyError
 from parsehawk.core.domain.models import (
     Example,
     Extractor,
@@ -24,34 +37,86 @@ from parsehawk.core.domain.models import (
     utc_now,
 )
 from parsehawk.server.adapters.persistence.migrations import apply_pending
+from parsehawk.server.adapters.persistence.tables import (
+    extractors as extractors_table,
+)
+from parsehawk.server.adapters.persistence.tables import files as files_table
+from parsehawk.server.adapters.persistence.tables import jobs as jobs_table
+from parsehawk.server.adapters.persistence.tables import (
+    provider_secrets as provider_secrets_table,
+)
+from parsehawk.server.adapters.persistence.tables import providers as providers_table
 from parsehawk.server.adapters.security import SecretCipher
 
-# A single sqlite3.Connection is shared across FastAPI's request threadpool, so
-# multi-statement write transactions (e.g. claim_next_queued's BEGIN IMMEDIATE)
-# can interleave across threads. This process-wide lock serializes writes so each
-# transaction is atomic; busy_timeout/WAL below handle the separate worker process.
-_write_lock = threading.RLock()
+DEFAULT_BUSY_TIMEOUT_MS = 5_000
+_BUSY_MESSAGES = (
+    "database is busy",
+    "database is locked",
+    "database schema is locked",
+    "database table is locked",
+)
 
 
-def connect(database_path: Path) -> sqlite3.Connection:
+def connect(
+    database_path: Path, *, busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS
+) -> sqlite3.Connection:
+    """Open a configured raw connection for migrations and maintenance commands."""
     database_path.parent.mkdir(parents=True, exist_ok=True)
-    conn = sqlite3.connect(database_path, check_same_thread=False)
+    conn = sqlite3.connect(
+        database_path,
+        check_same_thread=False,
+        timeout=busy_timeout_ms / 1_000,
+    )
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA foreign_keys = ON")
-    # Wait (rather than fail immediately with "database is locked") when another
-    # connection holds the write lock, and use WAL so readers don't block writers.
-    conn.execute("PRAGMA busy_timeout = 5000")
+    _configure_dbapi_connection(conn, busy_timeout_ms=busy_timeout_ms)
     conn.execute("PRAGMA journal_mode = WAL")
     return conn
 
 
-def init_db(conn: sqlite3.Connection) -> None:
-    """Bring the database schema up to date by applying pending migrations.
+def create_sqlite_engine(
+    database_path: Path, *, busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS
+) -> Engine:
+    """Create the process-lifetime engine used by short-lived Units of Work."""
+    database_path.parent.mkdir(parents=True, exist_ok=True)
+    engine = create_engine(
+        URL.create("sqlite+pysqlite", database=str(database_path)),
+        connect_args={
+            "check_same_thread": False,
+            "timeout": busy_timeout_ms / 1_000,
+        },
+    )
 
-    The schema is no longer defined inline here: ordered, tracked migrations under
-    ``migrations/`` own the DDL, and the runner is safe to call repeatedly.
-    """
+    @event.listens_for(engine, "connect")
+    def configure_connection(dbapi_connection: sqlite3.Connection, _: object) -> None:
+        _configure_dbapi_connection(dbapi_connection, busy_timeout_ms=busy_timeout_ms)
+
+    raw_connection = engine.raw_connection()
+    try:
+        dbapi_connection = cast(sqlite3.Connection, raw_connection.driver_connection)
+        dbapi_connection.execute("PRAGMA journal_mode = WAL")
+    finally:
+        raw_connection.close()
+    return engine
+
+
+def _configure_dbapi_connection(conn: sqlite3.Connection, *, busy_timeout_ms: int) -> None:
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(f"PRAGMA busy_timeout = {busy_timeout_ms}")
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    """Bring a raw SQLite connection up to the current migrated schema."""
     apply_pending(conn)
+
+
+def init_engine(engine: Engine) -> None:
+    """Apply migrations through one engine-owned DBAPI connection."""
+    raw_connection = engine.raw_connection()
+    try:
+        dbapi_connection = cast(sqlite3.Connection, raw_connection.driver_connection)
+        apply_pending(dbapi_connection)
+    finally:
+        raw_connection.close()
 
 
 def _dump_json(value: Any) -> str:
@@ -68,6 +133,20 @@ def _datetime_to_text(value: datetime | None) -> str | None:
 
 def _datetime_from_text(value: str | None) -> datetime | None:
     return datetime.fromisoformat(value) if value is not None else None
+
+
+def _is_busy_error(exc: BaseException) -> bool:
+    candidate: BaseException = exc
+    if isinstance(exc, DBAPIError) and isinstance(exc.orig, BaseException):
+        candidate = exc.orig
+    return isinstance(candidate, sqlite3.OperationalError) and any(
+        message in str(candidate).lower() for message in _BUSY_MESSAGES
+    )
+
+
+def _raise_if_busy(exc: BaseException) -> None:
+    if _is_busy_error(exc):
+        raise PersistenceBusyError() from exc
 
 
 @dataclass(frozen=True)
@@ -99,7 +178,7 @@ class SQLiteFileRow:
         )
 
     @classmethod
-    def from_sqlite(cls, row: sqlite3.Row) -> SQLiteFileRow:
+    def from_mapping(cls, row: RowMapping) -> SQLiteFileRow:
         return cls(**dict(row))
 
     def to_domain(self) -> File:
@@ -160,7 +239,7 @@ class SQLiteExtractorRow:
         )
 
     @classmethod
-    def from_sqlite(cls, row: sqlite3.Row) -> SQLiteExtractorRow:
+    def from_mapping(cls, row: RowMapping) -> SQLiteExtractorRow:
         return cls(**dict(row))
 
     def to_domain(self) -> Extractor:
@@ -194,14 +273,14 @@ class SQLiteJobRow:
     extractor_id: str
     file_id: str | None
     source_text: str | None
-    provider_name_used: str | None
-    model_used: str | None
     status: str
     result: str | None
     error: str | None
     created_at: str
     started_at: str | None
     completed_at: str | None
+    provider_name_used: str | None
+    model_used: str | None
 
     @classmethod
     def from_domain(cls, job: Job) -> SQLiteJobRow:
@@ -210,18 +289,18 @@ class SQLiteJobRow:
             extractor_id=job.extractor_id,
             file_id=job.file_id,
             source_text=job.source_text,
-            provider_name_used=job.provider_name_used.value if job.provider_name_used else None,
-            model_used=job.model_used,
             status=job.status.value,
             result=_dump_json(job.result.model_dump(mode="json")) if job.result else None,
             error=_dump_json(job.error.model_dump(mode="json")) if job.error else None,
             created_at=job.created_at.isoformat(),
             started_at=_datetime_to_text(job.started_at),
             completed_at=_datetime_to_text(job.completed_at),
+            provider_name_used=job.provider_name_used.value if job.provider_name_used else None,
+            model_used=job.model_used,
         )
 
     @classmethod
-    def from_sqlite(cls, row: sqlite3.Row) -> SQLiteJobRow:
+    def from_mapping(cls, row: RowMapping) -> SQLiteJobRow:
         return cls(**dict(row))
 
     def to_domain(self) -> Job:
@@ -245,304 +324,26 @@ class SQLiteJobRow:
         )
 
 
-class SQLiteFileRepository:
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self._conn = conn
-
-    def save(self, file: File) -> None:
-        row = SQLiteFileRow.from_domain(file)
-        with _write_lock:
-            self._conn.execute(
-                """
-                INSERT INTO files (
-                    id, file_name, content_type, size_bytes, sha256, storage_path,
-                    source, seed_key, seed_version, created_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    file_name = excluded.file_name,
-                    content_type = excluded.content_type,
-                    size_bytes = excluded.size_bytes,
-                    sha256 = excluded.sha256,
-                    storage_path = excluded.storage_path,
-                    source = excluded.source,
-                    seed_key = excluded.seed_key,
-                    seed_version = excluded.seed_version,
-                    created_at = excluded.created_at
-                """,
-                (
-                    row.id,
-                    row.file_name,
-                    row.content_type,
-                    row.size_bytes,
-                    row.sha256,
-                    row.storage_path,
-                    row.source,
-                    row.seed_key,
-                    row.seed_version,
-                    row.created_at,
-                ),
-            )
-            self._conn.commit()
-
-    def list(self) -> List[File]:
-        rows = self._conn.execute("SELECT * FROM files ORDER BY id").fetchall()
-        return [SQLiteFileRow.from_sqlite(row).to_domain() for row in rows]
-
-    def get(self, file_id: str) -> File | None:
-        row = self._conn.execute("SELECT * FROM files WHERE id = ?", (file_id,)).fetchone()
-        return SQLiteFileRow.from_sqlite(row).to_domain() if row else None
-
-    def delete(self, file_id: str) -> None:
-        with _write_lock:
-            self._conn.execute("DELETE FROM files WHERE id = ?", (file_id,))
-            self._conn.commit()
-
-
-class SQLiteExtractorRepository:
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self._conn = conn
-
-    def save(self, extractor: Extractor) -> None:
-        row = SQLiteExtractorRow.from_domain(extractor)
-        with _write_lock:
-            self._conn.execute(
-                """
-                INSERT INTO extractors (
-                    id, name, display_name, instructions, reasoning_effort, provider_name, model,
-                    schema, examples, source, seed_key, seed_version, created_at, updated_at
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    name = excluded.name,
-                    display_name = excluded.display_name,
-                    instructions = excluded.instructions,
-                    reasoning_effort = excluded.reasoning_effort,
-                    provider_name = excluded.provider_name,
-                    model = excluded.model,
-                    schema = excluded.schema,
-                    examples = excluded.examples,
-                    source = excluded.source,
-                    seed_key = excluded.seed_key,
-                    seed_version = excluded.seed_version,
-                    created_at = excluded.created_at,
-                    updated_at = excluded.updated_at
-                """,
-                (
-                    row.id,
-                    row.name,
-                    row.display_name,
-                    row.instructions,
-                    row.reasoning_effort,
-                    row.provider_name,
-                    row.model,
-                    row.schema,
-                    row.examples,
-                    row.source,
-                    row.seed_key,
-                    row.seed_version,
-                    row.created_at,
-                    row.updated_at,
-                ),
-            )
-            self._conn.commit()
-
-    def list(self) -> List[Extractor]:
-        rows = self._conn.execute("SELECT * FROM extractors ORDER BY id").fetchall()
-        return [SQLiteExtractorRow.from_sqlite(row).to_domain() for row in rows]
-
-    def get(self, extractor_id: str) -> Extractor | None:
-        row = self._conn.execute(
-            "SELECT * FROM extractors WHERE id = ?", (extractor_id,)
-        ).fetchone()
-        return SQLiteExtractorRow.from_sqlite(row).to_domain() if row else None
-
-    def get_by_name(self, name: str) -> Extractor | None:
-        row = self._conn.execute("SELECT * FROM extractors WHERE name = ?", (name,)).fetchone()
-        return SQLiteExtractorRow.from_sqlite(row).to_domain() if row else None
-
-    def delete(self, extractor_id: str) -> None:
-        with _write_lock:
-            self._conn.execute("DELETE FROM extractors WHERE id = ?", (extractor_id,))
-            self._conn.commit()
-
-
-class SQLiteJobRepository:
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self._conn = conn
-
-    def save(self, job: Job) -> None:
-        row = SQLiteJobRow.from_domain(job)
-        with _write_lock:
-            self._conn.execute(
-                """
-                INSERT INTO jobs (
-                    id, extractor_id, file_id, source_text, status, result, error,
-                    created_at, started_at, completed_at, provider_name_used, model_used
-                )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(id) DO UPDATE SET
-                    extractor_id = excluded.extractor_id,
-                    file_id = excluded.file_id,
-                    source_text = excluded.source_text,
-                    status = excluded.status,
-                    result = excluded.result,
-                    error = excluded.error,
-                    created_at = excluded.created_at,
-                    started_at = excluded.started_at,
-                    completed_at = excluded.completed_at,
-                    provider_name_used = excluded.provider_name_used,
-                    model_used = excluded.model_used
-                """,
-                (
-                    row.id,
-                    row.extractor_id,
-                    row.file_id,
-                    row.source_text,
-                    row.status,
-                    row.result,
-                    row.error,
-                    row.created_at,
-                    row.started_at,
-                    row.completed_at,
-                    row.provider_name_used,
-                    row.model_used,
-                ),
-            )
-            self._conn.commit()
-
-    def save_if_status(self, job: Job, expected: Iterable[JobStatus]) -> bool:
-        statuses = tuple(status.value for status in expected)
-        if not statuses:
-            return False
-        row = SQLiteJobRow.from_domain(job)
-        placeholders = ",".join("?" for _ in statuses)
-        with _write_lock:
-            cursor = self._conn.execute(
-                f"""
-                UPDATE jobs
-                SET extractor_id = ?,
-                    file_id = ?,
-                    source_text = ?,
-                    status = ?,
-                    result = ?,
-                    error = ?,
-                    created_at = ?,
-                    started_at = ?,
-                    completed_at = ?,
-                    provider_name_used = ?,
-                    model_used = ?
-                WHERE id = ? AND status IN ({placeholders})
-                """,
-                (
-                    row.extractor_id,
-                    row.file_id,
-                    row.source_text,
-                    row.status,
-                    row.result,
-                    row.error,
-                    row.created_at,
-                    row.started_at,
-                    row.completed_at,
-                    row.provider_name_used,
-                    row.model_used,
-                    row.id,
-                    *statuses,
-                ),
-            )
-            self._conn.commit()
-            return cursor.rowcount == 1
-
-    def list(self, extractor_id: str | None = None) -> List[Job]:
-        if extractor_id is None:
-            rows = self._conn.execute("SELECT * FROM jobs ORDER BY created_at").fetchall()
-        else:
-            rows = self._conn.execute(
-                "SELECT * FROM jobs WHERE extractor_id = ? ORDER BY created_at",
-                (extractor_id,),
-            ).fetchall()
-        return [SQLiteJobRow.from_sqlite(row).to_domain() for row in rows]
-
-    def get(self, job_id: str) -> Job | None:
-        row = self._conn.execute("SELECT * FROM jobs WHERE id = ?", (job_id,)).fetchone()
-        return SQLiteJobRow.from_sqlite(row).to_domain() if row else None
-
-    def delete(self, job_id: str) -> None:
-        with _write_lock:
-            self._conn.execute("DELETE FROM jobs WHERE id = ?", (job_id,))
-            self._conn.commit()
-
-    def delete_if_status(self, job_id: str, expected: Iterable[JobStatus]) -> bool:
-        statuses = tuple(status.value for status in expected)
-        if not statuses:
-            return False
-        placeholders = ",".join("?" for _ in statuses)
-        with _write_lock:
-            cursor = self._conn.execute(
-                f"DELETE FROM jobs WHERE id = ? AND status IN ({placeholders})",
-                (job_id, *statuses),
-            )
-            self._conn.commit()
-            return cursor.rowcount == 1
-
-    def claim_next_queued(self) -> Job | None:
-        with _write_lock:
-            try:
-                self._conn.execute("BEGIN IMMEDIATE")
-                row = self._conn.execute(
-                    """
-                    SELECT * FROM jobs
-                    WHERE status = ?
-                    ORDER BY created_at
-                    LIMIT 1
-                    """,
-                    (JobStatus.QUEUED.value,),
-                ).fetchone()
-                if row is None:
-                    self._conn.commit()
-                    return None
-                job = SQLiteJobRow.from_sqlite(row).to_domain().mark_running()
-                updated = SQLiteJobRow.from_domain(job)
-                self._conn.execute(
-                    """
-                    UPDATE jobs
-                    SET status = ?, started_at = ?
-                    WHERE id = ? AND status = ?
-                    """,
-                    (
-                        updated.status,
-                        updated.started_at,
-                        updated.id,
-                        JobStatus.QUEUED.value,
-                    ),
-                )
-                self._conn.commit()
-                return job
-            except Exception:
-                self._conn.rollback()
-                raise
-
-
 @dataclass(frozen=True)
 class SQLiteProviderRow:
     name: str
     base_url: str | None
-    configuration: str
     created_at: str
     updated_at: str
+    configuration: str
 
     @classmethod
     def from_domain(cls, provider: Provider) -> SQLiteProviderRow:
         return cls(
             name=provider.name.value,
             base_url=provider.base_url,
-            configuration=_dump_json(provider.configuration),
             created_at=provider.created_at.isoformat(),
             updated_at=provider.updated_at.isoformat(),
+            configuration=_dump_json(provider.configuration),
         )
 
     @classmethod
-    def from_sqlite(cls, row: sqlite3.Row) -> SQLiteProviderRow:
+    def from_mapping(cls, row: RowMapping) -> SQLiteProviderRow:
         return cls(**dict(row))
 
     def to_domain(self) -> Provider:
@@ -559,77 +360,366 @@ class SQLiteProviderRow:
         )
 
 
+class SQLiteFileRepository:
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
+
+    def save(self, file: File) -> None:
+        values = asdict(SQLiteFileRow.from_domain(file))
+        statement = sqlite_insert(files_table).values(**values)
+        statement = statement.on_conflict_do_update(
+            index_elements=[files_table.c.id],
+            set_={
+                column.name: statement.excluded[column.name]
+                for column in files_table.c
+                if column.name != "id"
+            },
+        )
+        self._connection.execute(statement)
+
+    def list(self) -> List[File]:
+        rows = self._connection.execute(select(files_table).order_by(files_table.c.id)).mappings()
+        return [SQLiteFileRow.from_mapping(row).to_domain() for row in rows]
+
+    def get(self, file_id: str) -> File | None:
+        row = (
+            self._connection.execute(select(files_table).where(files_table.c.id == file_id))
+            .mappings()
+            .first()
+        )
+        return SQLiteFileRow.from_mapping(row).to_domain() if row else None
+
+    def delete(self, file_id: str) -> None:
+        self._connection.execute(delete(files_table).where(files_table.c.id == file_id))
+
+
+class SQLiteExtractorRepository:
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
+
+    def save(self, extractor: Extractor) -> None:
+        values = asdict(SQLiteExtractorRow.from_domain(extractor))
+        statement = sqlite_insert(extractors_table).values(**values)
+        statement = statement.on_conflict_do_update(
+            index_elements=[extractors_table.c.id],
+            set_={
+                column.name: statement.excluded[column.name]
+                for column in extractors_table.c
+                if column.name != "id"
+            },
+        )
+        self._connection.execute(statement)
+
+    def list(self) -> List[Extractor]:
+        rows = self._connection.execute(
+            select(extractors_table).order_by(extractors_table.c.id)
+        ).mappings()
+        return [SQLiteExtractorRow.from_mapping(row).to_domain() for row in rows]
+
+    def get(self, extractor_id: str) -> Extractor | None:
+        row = (
+            self._connection.execute(
+                select(extractors_table).where(extractors_table.c.id == extractor_id)
+            )
+            .mappings()
+            .first()
+        )
+        return SQLiteExtractorRow.from_mapping(row).to_domain() if row else None
+
+    def get_by_name(self, name: str) -> Extractor | None:
+        row = (
+            self._connection.execute(
+                select(extractors_table).where(extractors_table.c.name == name)
+            )
+            .mappings()
+            .first()
+        )
+        return SQLiteExtractorRow.from_mapping(row).to_domain() if row else None
+
+    def delete(self, extractor_id: str) -> None:
+        self._connection.execute(
+            delete(extractors_table).where(extractors_table.c.id == extractor_id)
+        )
+
+
+class SQLiteJobRepository:
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
+
+    def save(self, job: Job) -> None:
+        values = asdict(SQLiteJobRow.from_domain(job))
+        statement = sqlite_insert(jobs_table).values(**values)
+        statement = statement.on_conflict_do_update(
+            index_elements=[jobs_table.c.id],
+            set_={
+                column.name: statement.excluded[column.name]
+                for column in jobs_table.c
+                if column.name != "id"
+            },
+        )
+        self._connection.execute(statement)
+
+    def save_if_status(self, job: Job, expected: Iterable[JobStatus]) -> bool:
+        statuses = tuple(status.value for status in expected)
+        if not statuses:
+            return False
+        values = asdict(SQLiteJobRow.from_domain(job))
+        job_id = values.pop("id")
+        result = self._connection.execute(
+            update(jobs_table)
+            .where(jobs_table.c.id == job_id)
+            .where(jobs_table.c.status.in_(statuses))
+            .values(**values)
+        )
+        return result.rowcount == 1
+
+    def list(self, extractor_id: str | None = None) -> List[Job]:
+        statement = select(jobs_table)
+        if extractor_id is not None:
+            statement = statement.where(jobs_table.c.extractor_id == extractor_id)
+        rows = self._connection.execute(statement.order_by(jobs_table.c.created_at)).mappings()
+        return [SQLiteJobRow.from_mapping(row).to_domain() for row in rows]
+
+    def get(self, job_id: str) -> Job | None:
+        row = (
+            self._connection.execute(select(jobs_table).where(jobs_table.c.id == job_id))
+            .mappings()
+            .first()
+        )
+        return SQLiteJobRow.from_mapping(row).to_domain() if row else None
+
+    def delete(self, job_id: str) -> None:
+        self._connection.execute(delete(jobs_table).where(jobs_table.c.id == job_id))
+
+    def delete_if_status(self, job_id: str, expected: Iterable[JobStatus]) -> bool:
+        statuses = tuple(status.value for status in expected)
+        if not statuses:
+            return False
+        result = self._connection.execute(
+            delete(jobs_table)
+            .where(jobs_table.c.id == job_id)
+            .where(jobs_table.c.status.in_(statuses))
+        )
+        return result.rowcount == 1
+
+    def claim_next_queued(self) -> Job | None:
+        row = (
+            self._connection.execute(
+                select(jobs_table)
+                .where(jobs_table.c.status == JobStatus.QUEUED.value)
+                .order_by(jobs_table.c.created_at)
+                .limit(1)
+            )
+            .mappings()
+            .first()
+        )
+        if row is None:
+            return None
+        claimed = SQLiteJobRow.from_mapping(row).to_domain().mark_running()
+        updated = SQLiteJobRow.from_domain(claimed)
+        result = self._connection.execute(
+            update(jobs_table)
+            .where(jobs_table.c.id == updated.id)
+            .where(jobs_table.c.status == JobStatus.QUEUED.value)
+            .values(status=updated.status, started_at=updated.started_at)
+        )
+        return claimed if result.rowcount == 1 else None
+
+    def has_for_file(self, file_id: str) -> bool:
+        return (
+            self._connection.execute(
+                select(jobs_table.c.id).where(jobs_table.c.file_id == file_id).limit(1)
+            ).first()
+            is not None
+        )
+
+    def has_for_extractor(self, extractor_id: str) -> bool:
+        return (
+            self._connection.execute(
+                select(jobs_table.c.id).where(jobs_table.c.extractor_id == extractor_id).limit(1)
+            ).first()
+            is not None
+        )
+
+
 class SQLiteProviderRepository:
-    def __init__(self, conn: sqlite3.Connection) -> None:
-        self._conn = conn
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
 
     def save(self, provider: Provider) -> None:
-        row = SQLiteProviderRow.from_domain(provider)
-        with _write_lock:
-            self._conn.execute(
-                """
-                INSERT INTO providers (name, base_url, configuration, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?)
-                ON CONFLICT(name) DO UPDATE SET
-                    base_url = excluded.base_url,
-                    configuration = excluded.configuration,
-                    updated_at = excluded.updated_at
-                """,
-                (row.name, row.base_url, row.configuration, row.created_at, row.updated_at),
-            )
-            self._conn.commit()
+        values = asdict(SQLiteProviderRow.from_domain(provider))
+        statement = sqlite_insert(providers_table).values(**values)
+        statement = statement.on_conflict_do_update(
+            index_elements=[providers_table.c.name],
+            set_={
+                "base_url": statement.excluded.base_url,
+                "configuration": statement.excluded.configuration,
+                "updated_at": statement.excluded.updated_at,
+            },
+        )
+        self._connection.execute(statement)
 
     def list(self) -> List[Provider]:
-        rows = self._conn.execute("SELECT * FROM providers ORDER BY name").fetchall()
-        return [SQLiteProviderRow.from_sqlite(row).to_domain() for row in rows]
+        rows = self._connection.execute(
+            select(providers_table).order_by(providers_table.c.name)
+        ).mappings()
+        return [SQLiteProviderRow.from_mapping(row).to_domain() for row in rows]
 
     def get(self, name: ProviderName) -> Provider | None:
-        row = self._conn.execute("SELECT * FROM providers WHERE name = ?", (name.value,)).fetchone()
-        return SQLiteProviderRow.from_sqlite(row).to_domain() if row else None
+        row = (
+            self._connection.execute(
+                select(providers_table).where(providers_table.c.name == name.value)
+            )
+            .mappings()
+            .first()
+        )
+        return SQLiteProviderRow.from_mapping(row).to_domain() if row else None
 
 
 class SQLiteSecretStore:
-    """Stores provider API keys encrypted at rest, keyed by provider name."""
+    """Store provider API keys encrypted at rest, keyed by provider name."""
 
-    def __init__(self, conn: sqlite3.Connection, cipher: SecretCipher) -> None:
-        self._conn = conn
+    def __init__(self, connection: Connection, cipher: SecretCipher) -> None:
+        self._connection = connection
         self._cipher = cipher
 
     def put(self, provider_name: ProviderName, api_key: str) -> None:
-        ciphertext = self._cipher.encrypt(api_key)
         now = utc_now().isoformat()
-        with _write_lock:
-            self._conn.execute(
-                """
-                INSERT INTO provider_secrets (provider_name, ciphertext, created_at, updated_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(provider_name) DO UPDATE SET
-                    ciphertext = excluded.ciphertext,
-                    updated_at = excluded.updated_at
-                """,
-                (provider_name.value, ciphertext, now, now),
-            )
-            self._conn.commit()
+        statement = sqlite_insert(provider_secrets_table).values(
+            provider_name=provider_name.value,
+            ciphertext=self._cipher.encrypt(api_key),
+            created_at=now,
+            updated_at=now,
+        )
+        statement = statement.on_conflict_do_update(
+            index_elements=[provider_secrets_table.c.provider_name],
+            set_={
+                "ciphertext": statement.excluded.ciphertext,
+                "updated_at": statement.excluded.updated_at,
+            },
+        )
+        self._connection.execute(statement)
 
     def get(self, provider_name: ProviderName) -> str | None:
-        row = self._conn.execute(
-            "SELECT ciphertext FROM provider_secrets WHERE provider_name = ?",
-            (provider_name.value,),
-        ).fetchone()
+        row = (
+            self._connection.execute(
+                select(provider_secrets_table.c.ciphertext).where(
+                    provider_secrets_table.c.provider_name == provider_name.value
+                )
+            )
+            .mappings()
+            .first()
+        )
         return self._cipher.decrypt(row["ciphertext"]) if row else None
 
     def delete(self, provider_name: ProviderName) -> None:
-        with _write_lock:
-            self._conn.execute(
-                "DELETE FROM provider_secrets WHERE provider_name = ?", (provider_name.value,)
+        self._connection.execute(
+            delete(provider_secrets_table).where(
+                provider_secrets_table.c.provider_name == provider_name.value
             )
-            self._conn.commit()
+        )
 
     def has(self, provider_name: ProviderName) -> bool:
-        row = self._conn.execute(
-            "SELECT 1 FROM provider_secrets WHERE provider_name = ?", (provider_name.value,)
-        ).fetchone()
-        return row is not None
+        return (
+            self._connection.execute(
+                select(provider_secrets_table.c.provider_name)
+                .where(provider_secrets_table.c.provider_name == provider_name.value)
+                .limit(1)
+            ).first()
+            is not None
+        )
+
+
+class SQLiteUnitOfWork:
+    """One SQLAlchemy Core connection and transaction for one application use case."""
+
+    files: FileRepository
+    extractors: ExtractorRepository
+    jobs: JobRepository
+    providers: ProviderRepository
+    secrets: SecretStore
+
+    def __init__(self, engine: Engine, cipher: SecretCipher, *, write: bool) -> None:
+        self._engine = engine
+        self._cipher = cipher
+        self._write = write
+        self._connection: Connection | None = None
+
+    def __enter__(self) -> SQLiteUnitOfWork:
+        self._connection = self._engine.connect()
+        try:
+            if self._write:
+                self._connection.exec_driver_sql("BEGIN IMMEDIATE")
+            else:
+                self._connection.begin()
+        except BaseException as exc:
+            self._connection.close()
+            self._connection = None
+            _raise_if_busy(exc)
+            raise
+        self.files = SQLiteFileRepository(self._connection)
+        self.extractors = SQLiteExtractorRepository(self._connection)
+        self.jobs = SQLiteJobRepository(self._connection)
+        self.providers = SQLiteProviderRepository(self._connection)
+        self.secrets = SQLiteSecretStore(self._connection, self._cipher)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        traceback: object,
+    ) -> None:
+        connection = self._require_connection()
+        cleanup_error: BaseException | None = None
+        try:
+            if connection.in_transaction():
+                connection.rollback()
+        except BaseException as rollback_error:
+            cleanup_error = rollback_error
+        finally:
+            connection.close()
+            self._connection = None
+        if exc is not None:
+            _raise_if_busy(exc)
+        if cleanup_error is not None:
+            _raise_if_busy(cleanup_error)
+            raise cleanup_error
+
+    def commit(self) -> None:
+        connection = self._require_connection()
+        try:
+            connection.commit()
+        except BaseException as exc:
+            if connection.in_transaction():
+                connection.rollback()
+            _raise_if_busy(exc)
+            raise
+
+    def rollback(self) -> None:
+        connection = self._require_connection()
+        try:
+            connection.rollback()
+        except BaseException as exc:
+            _raise_if_busy(exc)
+            raise
+
+    def _require_connection(self) -> Connection:
+        if self._connection is None:
+            raise RuntimeError("Unit of Work is not active")
+        return self._connection
+
+
+class SQLiteUnitOfWorkFactory:
+    def __init__(self, engine: Engine, cipher: SecretCipher) -> None:
+        self.engine = engine
+        self._cipher = cipher
+
+    def __call__(self, *, write: bool = False) -> UnitOfWork:
+        return SQLiteUnitOfWork(self.engine, self._cipher, write=write)
+
+    def close(self) -> None:
+        self.engine.dispose()
 
 
 def dump_debug_json(value: Any) -> str:

--- a/src/parsehawk/server/adapters/persistence/tables.py
+++ b/src/parsehawk/server/adapters/persistence/tables.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from sqlalchemy import Column, ForeignKey, Index, Integer, MetaData, Table, Text
+
+metadata = MetaData()
+
+files = Table(
+    "files",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column("file_name", Text, nullable=False),
+    Column("content_type", Text, nullable=False),
+    Column("size_bytes", Integer, nullable=False),
+    Column("sha256", Text, nullable=False),
+    Column("storage_path", Text, nullable=False),
+    Column("source", Text, nullable=False),
+    Column("seed_key", Text),
+    Column("seed_version", Integer),
+    Column("created_at", Text, nullable=False),
+)
+
+extractors = Table(
+    "extractors",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column("name", Text, nullable=False),
+    Column("display_name", Text, nullable=False),
+    Column("instructions", Text, nullable=False),
+    Column("schema", Text, nullable=False),
+    Column("examples", Text, nullable=False),
+    Column("source", Text, nullable=False),
+    Column("seed_key", Text),
+    Column("seed_version", Integer),
+    Column("created_at", Text, nullable=False),
+    Column("updated_at", Text, nullable=False),
+    Column("provider_name", Text),
+    Column("model", Text),
+    Column("reasoning_effort", Text),
+)
+Index("idx_extractors_name", extractors.c.name, unique=True)
+
+jobs = Table(
+    "jobs",
+    metadata,
+    Column("id", Text, primary_key=True),
+    Column("extractor_id", ForeignKey("extractors.id", ondelete="RESTRICT"), nullable=False),
+    Column("file_id", ForeignKey("files.id", ondelete="RESTRICT")),
+    Column("source_text", Text),
+    Column("status", Text, nullable=False),
+    Column("result", Text),
+    Column("error", Text),
+    Column("created_at", Text, nullable=False),
+    Column("started_at", Text),
+    Column("completed_at", Text),
+    Column("provider_name_used", Text),
+    Column("model_used", Text),
+)
+Index("idx_jobs_extractor_id", jobs.c.extractor_id)
+Index("idx_jobs_status_created_at", jobs.c.status, jobs.c.created_at)
+
+providers = Table(
+    "providers",
+    metadata,
+    Column("name", Text, primary_key=True),
+    Column("base_url", Text),
+    Column("created_at", Text, nullable=False),
+    Column("updated_at", Text, nullable=False),
+    Column("configuration", Text, nullable=False),
+)
+
+provider_secrets = Table(
+    "provider_secrets",
+    metadata,
+    Column(
+        "provider_name",
+        ForeignKey("providers.name", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column("ciphertext", Text, nullable=False),
+    Column("created_at", Text, nullable=False),
+    Column("updated_at", Text, nullable=False),
+)

--- a/src/parsehawk/server/api/fastapi/app.py
+++ b/src/parsehawk/server/api/fastapi/app.py
@@ -23,7 +23,12 @@ from fastapi.responses import JSONResponse
 
 from parsehawk import telemetry, tracing
 from parsehawk.core.application.services import NOT_PROVIDED, DeleteJobResult
-from parsehawk.core.domain.errors import NotFoundError, ProviderRequestError, ValidationFailure
+from parsehawk.core.domain.errors import (
+    NotFoundError,
+    PersistenceBusyError,
+    ProviderRequestError,
+    ValidationFailure,
+)
 from parsehawk.core.domain.models import ProviderName
 from parsehawk.core.domain.schemas import (
     MODE_JSON_SCHEMA,
@@ -116,6 +121,10 @@ SERVER_ERROR_RESPONSE = {
     "model": ApiErrorResponse,
     "description": "Unexpected server error.",
 }
+PERSISTENCE_BUSY_RESPONSE = {
+    "model": ApiErrorResponse,
+    "description": "Persistence is temporarily busy and the request can be retried.",
+}
 
 files_router = APIRouter(prefix="/files", tags=["files"])
 extractors_router = APIRouter(prefix="/extractors", tags=["extractors"])
@@ -160,7 +169,7 @@ def create_app() -> FastAPI:
             }
         ],
         openapi_tags=OPENAPI_TAGS,
-        responses={500: SERVER_ERROR_RESPONSE},
+        responses={500: SERVER_ERROR_RESPONSE, 503: PERSISTENCE_BUSY_RESPONSE},
         lifespan=lifespan,
     )
 
@@ -175,6 +184,14 @@ def create_app() -> FastAPI:
     @app.exception_handler(ProviderRequestError)
     async def provider_request_handler(_: Request, exc: ProviderRequestError) -> JSONResponse:
         return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    @app.exception_handler(PersistenceBusyError)
+    async def persistence_busy_handler(_: Request, exc: PersistenceBusyError) -> JSONResponse:
+        return JSONResponse(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            content={"code": exc.code, "detail": str(exc)},
+            headers={"Retry-After": "1"},
+        )
 
     @app.exception_handler(Exception)
     async def unexpected_error_handler(_: Request, exc: Exception) -> JSONResponse:
@@ -359,7 +376,10 @@ def get_file_content(
     "/{file_id}",
     operation_id="deleteFile",
     summary="Delete a file",
-    description="Delete one stored file and its local content.",
+    description=(
+        "Delete one stored file and its local content. Files referenced by jobs must remain "
+        "until those jobs are deleted."
+    ),
     status_code=status.HTTP_204_NO_CONTENT,
     responses={404: NOT_FOUND_RESPONSE},
 )
@@ -477,7 +497,10 @@ def upsert_extractor(
     "/{extractor_ref}",
     operation_id="deleteExtractor",
     summary="Delete an extractor",
-    description="Delete a custom extractor. Built-in extractors cannot be deleted.",
+    description=(
+        "Delete a custom extractor. Built-in extractors and extractors referenced by jobs "
+        "cannot be deleted."
+    ),
     status_code=status.HTTP_204_NO_CONTENT,
     responses={404: NOT_FOUND_RESPONSE, 422: VALIDATION_ERROR_RESPONSE},
 )
@@ -552,8 +575,8 @@ def list_provider_models(
     name: Annotated[ProviderName, Path(description="Stable provider name.")],
     container: ContainerDep,
 ) -> ProviderModelsResponse:
-    provider = container.provider_service.get(name)
-    api_key = container.secrets.get(name) or "EMPTY"
+    provider, stored_api_key = container.provider_service.get_with_api_key(name)
+    api_key = stored_api_key or "EMPTY"
     if provider.name == ProviderName.MICROSOFT_FOUNDRY:
         models = list_foundry_chat_deployments(
             project_url=provider.project_url,

--- a/src/parsehawk/server/api/fastapi/app.py
+++ b/src/parsehawk/server/api/fastapi/app.py
@@ -381,7 +381,10 @@ def get_file_content(
         "until those jobs are deleted."
     ),
     status_code=status.HTTP_204_NO_CONTENT,
-    responses={404: NOT_FOUND_RESPONSE},
+    responses={
+        404: NOT_FOUND_RESPONSE,
+        422: VALIDATION_ERROR_RESPONSE,
+    },
 )
 def delete_file(
     file_id: Annotated[str, Path(description="Immutable file identifier.")],

--- a/src/parsehawk/server/api/fastapi/schemas.py
+++ b/src/parsehawk/server/api/fastapi/schemas.py
@@ -30,6 +30,10 @@ class ApiModel(BaseModel):
 class ApiErrorResponse(ApiModel):
     """Error returned by request validation or a ParseHawk domain service."""
 
+    code: str | None = Field(
+        default=None,
+        description="Stable machine-readable error code when the failure is retryable or actionable.",
+    )
     detail: str | list[dict[str, Any]] = Field(
         description=(
             "Human-readable error text, or FastAPI validation details when the request "

--- a/src/parsehawk/server/bootstrap/seeds.py
+++ b/src/parsehawk/server/bootstrap/seeds.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from parsehawk.config import Settings
-from parsehawk.core.domain.models import ExtractorSource, Provider, ProviderName, utc_now
+from parsehawk.core.domain.models import ExtractorSource, Provider, ProviderName
 from parsehawk.server.container import Container, build_container
 
 RECEIPT_EXTRACTOR_SEED_KEY = "prebuilt:receipt:v1"
@@ -72,18 +72,15 @@ def seed_providers_in_container(container: Container) -> None:
         ProviderName.MICROSOFT_FOUNDRY: None,
     }
     for name, base_url in default_base_urls.items():
-        provider = container.providers.get(name)
-        if provider is None:
-            container.providers.save(Provider(name=name, base_url=base_url))
-        elif (
-            name == ProviderName.OPENAI_COMPATIBLE
-            and base_url
-            and provider.base_url != base_url
-            and (provider.base_url is None or provider.base_url in KNOWN_BUNDLED_RUNTIME_BASE_URLS)
-        ):
-            container.providers.save(
-                provider.model_copy(update={"base_url": base_url, "updated_at": utc_now()})
-            )
+        replaceable = (
+            frozenset({None, *KNOWN_BUNDLED_RUNTIME_BASE_URLS})
+            if name == ProviderName.OPENAI_COMPATIBLE and base_url
+            else frozenset()
+        )
+        container.provider_service.ensure(
+            Provider(name=name, base_url=base_url),
+            replace_base_url_if=replaceable,
+        )
 
 
 def seed_prebuilt_data_in_container(container: Container) -> None:

--- a/src/parsehawk/server/container.py
+++ b/src/parsehawk/server/container.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import sqlite3
-
 from parsehawk.config import Settings
 from parsehawk.core.application.services import (
     ExtractorService,
@@ -11,13 +9,10 @@ from parsehawk.core.application.services import (
 )
 from parsehawk.server.adapters.persistence.migrations import migrations_disabled
 from parsehawk.server.adapters.persistence.sqlite import (
-    SQLiteExtractorRepository,
-    SQLiteFileRepository,
-    SQLiteJobRepository,
-    SQLiteProviderRepository,
-    SQLiteSecretStore,
-    connect,
-    init_db,
+    DEFAULT_BUSY_TIMEOUT_MS,
+    SQLiteUnitOfWorkFactory,
+    create_sqlite_engine,
+    init_engine,
 )
 from parsehawk.server.adapters.security import load_secret_cipher
 from parsehawk.server.adapters.storage.local import LocalFileStorage
@@ -25,43 +20,42 @@ from parsehawk.server.runtime.inference.factory import EngineFactory
 
 
 class Container:
-    def __init__(self, settings: Settings) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        sqlite_busy_timeout_ms: int = DEFAULT_BUSY_TIMEOUT_MS,
+    ) -> None:
         self.settings = settings
-        self.conn = connect(settings.resolved_database_path)
+        self.engine = create_sqlite_engine(
+            settings.resolved_database_path,
+            busy_timeout_ms=sqlite_busy_timeout_ms,
+        )
         # Serving processes bring the schema up to date on construction. The
         # PARSEHAWK_SKIP_MIGRATIONS opt-out lets an operator take ownership of when
         # migrations run (e.g. via `parsehawk migrate`) instead of auto-applying.
         if not migrations_disabled():
-            init_db(self.conn)
+            init_engine(self.engine)
         self.storage = LocalFileStorage(
             settings.data_dir,
             pdf_max_pages=settings.pdf_max_pages,
             pdf_render_dpi=settings.pdf_render_dpi,
         )
-        self.files = SQLiteFileRepository(self.conn)
-        self.extractors = SQLiteExtractorRepository(self.conn)
-        self.jobs = SQLiteJobRepository(self.conn)
-        self.providers = SQLiteProviderRepository(self.conn)
-        self.secrets = SQLiteSecretStore(
-            self.conn, load_secret_cipher(settings.data_dir, settings.secret_key)
+        self.uow_factory = SQLiteUnitOfWorkFactory(
+            self.engine,
+            load_secret_cipher(settings.data_dir, settings.secret_key),
         )
-        self.engine_factory = EngineFactory(self.providers, self.secrets, settings)
-        self.file_service = FileService(self.files, self.storage)
+        self.engine_factory = EngineFactory(settings)
+        self.file_service = FileService(self.uow_factory, self.storage)
         self.extractor_service = ExtractorService(
-            self.extractors, self.files, default_model=settings.vllm_model
+            self.uow_factory, default_model=settings.vllm_model
         )
-        self.provider_service = ProviderService(self.providers, self.secrets)
-        self.job_service = JobService(
-            self.jobs, self.files, self.extractors, self.storage, self.engine_factory
-        )
+        self.provider_service = ProviderService(self.uow_factory)
+        self.job_service = JobService(self.uow_factory, self.storage, self.engine_factory)
 
     def close(self) -> None:
-        self.conn.close()
+        self.uow_factory.close()
 
 
 def build_container(settings: Settings | None = None) -> Container:
     return Container(settings or Settings.from_env())
-
-
-def close_safely(conn: sqlite3.Connection) -> None:
-    conn.close()

--- a/src/parsehawk/server/runtime/inference/factory.py
+++ b/src/parsehawk/server/runtime/inference/factory.py
@@ -1,11 +1,10 @@
 """Resolve and cache an extraction engine per extractor.
 
-Each extractor names a provider and a model; the factory looks up the provider's
-connection config, decrypts its API key, and builds an ``OpenAIExtractionEngine``
-for that (provider, key, model) combination. Engines are cached per config so a
-provider edit or key rotation transparently yields a fresh client. One factory
-lives per process (the API and worker each have their own), reading providers
-and secrets from the shared SQLite database.
+Each extractor names a provider and model. The application service loads the
+provider configuration and key inside a short Unit of Work, then passes those
+immutable values here after the transaction closes. Engines are cached per
+configuration, so a provider edit or key rotation yields a fresh client without
+giving runtime code a database dependency.
 """
 
 from __future__ import annotations
@@ -13,13 +12,9 @@ from __future__ import annotations
 from typing import Any
 
 from parsehawk.config import Settings
-from parsehawk.core.application.ports import (
-    ProviderRepository,
-    ResolvedExecutionConfig,
-    SecretStore,
-)
+from parsehawk.core.application.ports import ResolvedExecutionConfig
 from parsehawk.core.application.services import DEFAULT_PROVIDER_NAME
-from parsehawk.core.domain.models import Extractor
+from parsehawk.core.domain.models import Extractor, Provider
 from parsehawk.server.runtime.inference.openai_engine import (
     OpenAIEngineConfig,
     OpenAIExtractionEngine,
@@ -27,11 +22,7 @@ from parsehawk.server.runtime.inference.openai_engine import (
 
 
 class EngineFactory:
-    def __init__(
-        self, providers: ProviderRepository, secrets: SecretStore, settings: Settings
-    ) -> None:
-        self._providers = providers
-        self._secrets = secrets
+    def __init__(self, settings: Settings) -> None:
         self._settings = settings
         self._cache: dict[tuple[Any, ...], OpenAIExtractionEngine] = {}
 
@@ -40,22 +31,27 @@ class EngineFactory:
         model = extractor.model or self._settings.vllm_model
         return ResolvedExecutionConfig(provider_name=provider_name, model=model)
 
-    def for_extractor(self, extractor: Extractor) -> OpenAIExtractionEngine:
+    def for_extractor(
+        self,
+        extractor: Extractor,
+        *,
+        provider: Provider | None = None,
+        api_key: str | None = None,
+    ) -> OpenAIExtractionEngine:
         resolved = self.resolve_extractor_config(extractor)
         provider_name = resolved.provider_name
         model = resolved.model
-        provider = self._providers.get(provider_name)
         base_url = provider.base_url if provider else None
-        api_key = self._secrets.get(provider_name) or "EMPTY"
+        resolved_api_key = api_key or "EMPTY"
 
-        cache_key = (provider_name.value, base_url, api_key, model)
+        cache_key = (provider_name.value, base_url, resolved_api_key, model)
         engine = self._cache.get(cache_key)
         if engine is None:
             engine = OpenAIExtractionEngine(
                 OpenAIEngineConfig(
                     model=model,
                     base_url=base_url,
-                    api_key=api_key,
+                    api_key=resolved_api_key,
                     max_tokens=self._settings.vllm_max_tokens,
                     temperature=self._settings.vllm_temperature,
                     timeout_seconds=self._settings.vllm_timeout_seconds,

--- a/src/parsehawk/server/worker/main.py
+++ b/src/parsehawk/server/worker/main.py
@@ -5,6 +5,7 @@ import logging
 import time
 
 from parsehawk import tracing
+from parsehawk.core.domain.errors import PersistenceBusyError
 from parsehawk.logging import configure_logging
 from parsehawk.server.container import build_container
 
@@ -25,7 +26,12 @@ def run_forever(poll_seconds: float) -> None:
     try:
         logger.info("Worker started")
         while True:
-            job = container.job_service.run_next_queued()
+            try:
+                job = container.job_service.run_next_queued()
+            except PersistenceBusyError:
+                logger.warning("Persistence busy; retrying after %.2f seconds", poll_seconds)
+                time.sleep(poll_seconds)
+                continue
             if job is None:
                 time.sleep(poll_seconds)
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,13 @@ class _StubEngineFactory:
             model=extractor.model or DEFAULT_VLLM_MODEL,
         )
 
-    def for_extractor(self, extractor: Extractor) -> MockInference:
+    def for_extractor(
+        self,
+        extractor: Extractor,
+        *,
+        provider=None,
+        api_key: str | None = None,
+    ) -> MockInference:
         return self._engine
 
 

--- a/tests/integration/api/test_api_concurrency.py
+++ b/tests/integration/api/test_api_concurrency.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Iterator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from parsehawk.config import Settings
+from parsehawk.server.api.fastapi.app import create_app, get_container
+from parsehawk.server.container import Container
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"value": {"type": "string"}},
+    "required": ["value"],
+    "additionalProperties": False,
+}
+
+
+@pytest.fixture
+def concurrent_client(tmp_path) -> Iterator[tuple[TestClient, Container]]:
+    settings = Settings(data_dir=tmp_path, database_path=tmp_path / "parsehawk.db")
+    container = Container(settings)
+    app = create_app()
+    app.dependency_overrides[get_container] = lambda: container
+    client = TestClient(app)
+    try:
+        yield client, container
+    finally:
+        client.close()
+        container.close()
+
+
+def create_extractor(client: TestClient, name: str = "concurrency_test") -> str:
+    response = client.post(
+        "/v1/extractors",
+        json={"name": name, "instructions": "Extract value.", "schema": _SCHEMA},
+    )
+    assert response.status_code == 201, response.text
+    return response.json()["id"]
+
+
+@pytest.mark.concurrency
+def test_parallel_job_workflows_have_no_false_not_found_or_server_errors(
+    concurrent_client: tuple[TestClient, Container],
+) -> None:
+    client, _container = concurrent_client
+    extractor_id = create_extractor(client)
+
+    def run_workflow(index: int) -> str:
+        created = client.post(
+            "/v1/jobs",
+            json={"extractor_id": extractor_id, "text": f"value {index}"},
+        )
+        assert created.status_code == 201, created.text
+        job_id = created.json()["id"]
+
+        fetched = client.get(f"/v1/jobs/{job_id}")
+        assert fetched.status_code == 200, fetched.text
+        listed = client.get(f"/v1/jobs?extractor_id={extractor_id}")
+        assert listed.status_code == 200, listed.text
+        assert job_id in {job["id"] for job in listed.json()}
+
+        canceled = client.post(f"/v1/jobs/{job_id}/cancel")
+        assert canceled.status_code == 200, canceled.text
+        assert canceled.json()["status"] == "canceled"
+        assert client.get(f"/v1/jobs/{job_id}").status_code == 200
+        assert client.delete(f"/v1/jobs/{job_id}").status_code == 204
+        return job_id
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        job_ids = list(executor.map(run_workflow, range(40)))
+
+    assert len(set(job_ids)) == 40
+
+
+@pytest.mark.concurrency
+def test_parent_deletion_is_rejected_until_job_is_explicitly_deleted(
+    concurrent_client: tuple[TestClient, Container],
+) -> None:
+    client, _container = concurrent_client
+    extractor_id = create_extractor(client, "parent_guard")
+    uploaded = client.post(
+        "/v1/files",
+        files={"upload": ("source.md", b"value", "text/markdown")},
+    )
+    assert uploaded.status_code == 201
+    file_id = uploaded.json()["id"]
+    created = client.post(
+        "/v1/jobs",
+        json={"extractor_id": extractor_id, "file_id": file_id},
+    )
+    assert created.status_code == 201
+    job_id = created.json()["id"]
+
+    assert client.delete(f"/v1/files/{file_id}").status_code == 422
+    assert client.delete(f"/v1/extractors/{extractor_id}").status_code == 422
+    assert client.get(f"/v1/jobs/{job_id}").status_code == 200
+
+    assert client.delete(f"/v1/jobs/{job_id}").status_code == 204
+    assert client.delete(f"/v1/files/{file_id}").status_code == 204
+    assert client.delete(f"/v1/extractors/{extractor_id}").status_code == 204
+
+
+@pytest.mark.concurrency
+def test_exhausted_write_contention_returns_retryable_503(
+    tmp_path,
+) -> None:
+    settings = Settings(data_dir=tmp_path, database_path=tmp_path / "parsehawk.db")
+    container = Container(settings, sqlite_busy_timeout_ms=50)
+    app = create_app()
+    app.dependency_overrides[get_container] = lambda: container
+    client = TestClient(app)
+    try:
+        extractor_id = create_extractor(client, "busy_test")
+
+        with container.uow_factory(write=True):
+            response = client.post(
+                "/v1/jobs",
+                json={"extractor_id": extractor_id, "text": "value"},
+            )
+
+        assert response.status_code == 503
+        assert response.json() == {
+            "code": "persistence_busy",
+            "detail": "Persistence is temporarily busy; retry the request",
+        }
+        assert response.headers["retry-after"] == "1"
+    finally:
+        client.close()
+        container.close()

--- a/tests/integration/api/test_api_concurrency.py
+++ b/tests/integration/api/test_api_concurrency.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import time
 from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 from typing import Iterator
 
 import pytest
 from fastapi.testclient import TestClient
 
 from parsehawk.config import Settings
+from parsehawk.core.application.ports import (
+    ExtractionRequest,
+    ExtractionResponse,
+    ResolvedExecutionConfig,
+)
+from parsehawk.core.application.services import JobService
+from parsehawk.core.domain.models import Extractor, JobStatus, ProviderName
 from parsehawk.server.api.fastapi.app import create_app, get_container
 from parsehawk.server.container import Container
 
@@ -16,6 +25,34 @@ _SCHEMA = {
     "required": ["value"],
     "additionalProperties": False,
 }
+
+
+class BlockingEngine:
+    def __init__(self) -> None:
+        self.started = Event()
+        self.release = Event()
+        self.calls = 0
+
+    def extract(self, request: ExtractionRequest, cancellation_check=None) -> ExtractionResponse:
+        self.calls += 1
+        self.started.set()
+        assert self.release.wait(timeout=5)
+        return ExtractionResponse(data={"value": request.source_text})
+
+
+class BlockingEngineFactory:
+    def __init__(self, engine: BlockingEngine, default_model: str) -> None:
+        self._engine = engine
+        self._default_model = default_model
+
+    def resolve_extractor_config(self, extractor: Extractor) -> ResolvedExecutionConfig:
+        return ResolvedExecutionConfig(
+            provider_name=extractor.provider_name or ProviderName.OPENAI_COMPATIBLE,
+            model=extractor.model or self._default_model,
+        )
+
+    def for_extractor(self, extractor: Extractor, *, provider=None, api_key=None) -> BlockingEngine:
+        return self._engine
 
 
 @pytest.fixture
@@ -129,4 +166,42 @@ def test_exhausted_write_contention_returns_retryable_503(
         assert response.headers["retry-after"] == "1"
     finally:
         client.close()
+        container.close()
+
+
+@pytest.mark.concurrency
+def test_claimed_job_retries_temporary_finalization_contention_without_rerunning_model(
+    tmp_path,
+) -> None:
+    settings = Settings(data_dir=tmp_path, database_path=tmp_path / "parsehawk.db")
+    container = Container(settings, sqlite_busy_timeout_ms=25)
+    engine = BlockingEngine()
+    job_service = JobService(
+        container.uow_factory,
+        container.storage,
+        BlockingEngineFactory(engine, settings.vllm_model),
+    )
+    try:
+        extractor = container.extractor_service.create(
+            name="finalization_contention",
+            instructions="Extract value.",
+            schema=_SCHEMA,
+        )
+        created = job_service.create(extractor_id=extractor.id, text="value")
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(job_service.run_next_queued)
+            assert engine.started.wait(timeout=5)
+            with container.uow_factory(write=True):
+                engine.release.set()
+                time.sleep(0.075)
+            completed = future.result(timeout=5)
+
+        assert completed is not None
+        assert completed.id == created.id
+        assert completed.status == JobStatus.COMPLETED
+        assert engine.calls == 1
+        assert job_service.get(created.id).status == JobStatus.COMPLETED
+    finally:
+        engine.release.set()
         container.close()

--- a/tests/integration/api/test_api_workflow.py
+++ b/tests/integration/api/test_api_workflow.py
@@ -189,14 +189,17 @@ def test_delete_running_job_returns_accepted_and_marks_deleting(monkeypatch, tmp
         assert job_response.status_code == 201
         job_id = job_response.json()["id"]
 
-        job = client.app.state.container.jobs.get(job_id)
-        assert job is not None
-        client.app.state.container.jobs.save(job.mark_running())
+        container = client.app.state.container
+        with container.uow_factory(write=True) as uow:
+            job = uow.jobs.get(job_id)
+            assert job is not None
+            uow.jobs.save(job.mark_running())
+            uow.commit()
 
         response = client.delete(f"/v1/jobs/{job_id}")
 
         assert response.status_code == 202
-        persisted = client.app.state.container.jobs.get(job_id)
+        persisted = container.job_service.get(job_id)
         assert persisted is not None
         assert persisted.status == JobStatus.DELETING
 

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1542,6 +1542,7 @@ def test_migrate_status_reports_applied_and_pending(
             "20260708130000_inherit_openai_compatible_default_model",
             "20260708133000_job_execution_model_metadata",
             "20260709090000_extractor_reasoning_effort",
+            "20260721120000_restrict_job_parent_deletion",
         ],
     }
 
@@ -1559,6 +1560,7 @@ def test_migrate_status_reports_applied_and_pending(
             "20260708130000_inherit_openai_compatible_default_model",
             "20260708133000_job_execution_model_metadata",
             "20260709090000_extractor_reasoning_effort",
+            "20260721120000_restrict_job_parent_deletion",
         ],
         "pending": [],
     }
@@ -1587,13 +1589,14 @@ def test_apply_migrations_at_start_applies_when_not_excluded(
 
     assert database_path.exists()
     assert (
-        "Applied 8 migration(s): 20260701092442_initial_schema, "
+        "Applied 9 migration(s): 20260701092442_initial_schema, "
         "20260701121138_add_providers, 20260702160000_extractor_display_names, "
         "20260708093000_provider_configuration, "
         "20260708112000_remove_foundry_api_version_config, "
         "20260708130000_inherit_openai_compatible_default_model, "
         "20260708133000_job_execution_model_metadata, "
-        "20260709090000_extractor_reasoning_effort" in capsys.readouterr().out
+        "20260709090000_extractor_reasoning_effort, "
+        "20260721120000_restrict_job_parent_deletion" in capsys.readouterr().out
     )
 
 

--- a/tests/unit/core/test_services.py
+++ b/tests/unit/core/test_services.py
@@ -342,6 +342,18 @@ class RacingDeleteJobRepository(MemoryJobRepository):
         return super().delete_if_status(job_id, expected)
 
 
+class BusyOnceCompletingJobRepository(MemoryJobRepository):
+    def __init__(self) -> None:
+        super().__init__()
+        self.busy_attempts = 0
+
+    def save_if_status(self, job: Job, expected: Iterable[JobStatus]) -> bool:
+        if job.status == JobStatus.COMPLETED and self.busy_attempts == 0:
+            self.busy_attempts += 1
+            raise PersistenceBusyError()
+        return super().save_if_status(job, expected)
+
+
 @dataclass
 class StubEngine:
     response: ExtractionResponse | None = None
@@ -1742,19 +1754,27 @@ def test_job_service_engine_exception_fails_job(services) -> None:
     assert "model unavailable" in completed.error.message
 
 
-def test_job_service_does_not_convert_persistence_contention_into_job_failure(
-    services,
+def test_job_service_retries_final_persistence_without_rerunning_inference(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    services["engine"].error = PersistenceBusyError()
-    file = services["file_service"].upload(file_name="a.md", content_type="", content=b"x")
-    extractor = services["extractor_service"].create(name="e", instructions="i", schema=schema())
-    job = services["job_service"].create(extractor_id=extractor.id, file_id=file.id)
+    monkeypatch.setattr(service_module.time, "sleep", lambda _: None)
+    files = MemoryFileRepository()
+    extractors = MemoryExtractorRepository()
+    jobs = BusyOnceCompletingJobRepository()
+    storage = MemoryStorage()
+    engine = StubEngine(response=ExtractionResponse(data={"receipt_id": "2"}))
+    uow = build_memory_uow(files, extractors, jobs)
+    extractor_service = ExtractorService(uow, default_model=DEFAULT_MODEL)
+    job_service = JobService(uow, storage, StubEngineFactory(engine))
+    extractor = extractor_service.create(name="e", instructions="i", schema=schema())
+    job_service.create(extractor_id=extractor.id, text="receipt 2")
 
-    with pytest.raises(PersistenceBusyError):
-        services["job_service"].run_claimed(job)
+    completed = job_service.run_next_queued()
 
-    persisted = services["job_service"].get(job.id)
-    assert persisted.status == JobStatus.RUNNING
+    assert completed is not None
+    assert completed.status == JobStatus.COMPLETED
+    assert jobs.busy_attempts == 1
+    assert len(engine.requests) == 1
 
 
 def test_job_service_missing_resources_during_run_fail_job(services) -> None:

--- a/tests/unit/core/test_services.py
+++ b/tests/unit/core/test_services.py
@@ -502,6 +502,29 @@ def test_file_service_rejects_deleting_example_files(services) -> None:
     assert file_service.get(file.id) == file
 
 
+def test_file_service_keeps_metadata_when_storage_deletion_fails(
+    services, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    file_service: FileService = services["file_service"]
+    storage: MemoryStorage = services["storage"]
+    file = file_service.upload(
+        file_name="retryable.md",
+        content_type="text/markdown",
+        content=b"hello",
+    )
+
+    def fail_delete(_: File) -> None:
+        raise PermissionError("storage is read-only")
+
+    monkeypatch.setattr(storage, "delete_file", fail_delete)
+
+    with pytest.raises(PermissionError, match="storage is read-only"):
+        file_service.delete(file.id)
+
+    assert file_service.get(file.id) == file
+    assert storage.contents[file.storage_path] == b"hello"
+
+
 def test_parent_resources_cannot_delete_jobs_implicitly(services) -> None:
     file = services["file_service"].upload(
         file_name="a.md", content_type="text/markdown", content=b"Receipt #2"

--- a/tests/unit/core/test_services.py
+++ b/tests/unit/core/test_services.py
@@ -10,9 +10,15 @@ from parsehawk.core.application import services as service_module
 from parsehawk.core.application.ports import (
     ExtractionRequest,
     ExtractionResponse,
+    ExtractorRepository,
+    FileRepository,
+    JobRepository,
     PreparedDocument,
     PreparedImage,
+    ProviderRepository,
     ResolvedExecutionConfig,
+    SecretStore,
+    UnitOfWork,
 )
 from parsehawk.core.application.services import (
     DeleteJobResult,
@@ -21,7 +27,12 @@ from parsehawk.core.application.services import (
     JobService,
     ProviderService,
 )
-from parsehawk.core.domain.errors import ExtractionCancelled, NotFoundError, ValidationFailure
+from parsehawk.core.domain.errors import (
+    ExtractionCancelled,
+    NotFoundError,
+    PersistenceBusyError,
+    ValidationFailure,
+)
 from parsehawk.core.domain.models import (
     ExampleInputKind,
     Extractor,
@@ -117,6 +128,12 @@ class MemoryJobRepository:
                 return claimed
         return None
 
+    def has_for_file(self, file_id: str) -> bool:
+        return any(job.file_id == file_id for job in self.items.values())
+
+    def has_for_extractor(self, extractor_id: str) -> bool:
+        return any(job.extractor_id == extractor_id for job in self.items.values())
+
 
 class MemoryProviderRepository:
     def __init__(self) -> None:
@@ -147,6 +164,66 @@ class MemorySecretStore:
 
     def has(self, provider_name: ProviderName) -> bool:
         return provider_name in self.items
+
+
+class MemoryUnitOfWork:
+    files: FileRepository
+    extractors: ExtractorRepository
+    jobs: JobRepository
+    providers: ProviderRepository
+    secrets: SecretStore
+
+    def __init__(
+        self,
+        files: MemoryFileRepository,
+        extractors: MemoryExtractorRepository,
+        jobs: MemoryJobRepository,
+        providers: MemoryProviderRepository,
+        secrets: MemorySecretStore,
+    ) -> None:
+        self.files = files
+        self.extractors = extractors
+        self.jobs = jobs
+        self.providers = providers
+        self.secrets = secrets
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+    def commit(self) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+
+class MemoryUnitOfWorkFactory:
+    def __init__(
+        self,
+        *,
+        files: MemoryFileRepository | None = None,
+        extractors: MemoryExtractorRepository | None = None,
+        jobs: MemoryJobRepository | None = None,
+        providers: MemoryProviderRepository | None = None,
+        secrets: MemorySecretStore | None = None,
+    ) -> None:
+        self.files = files or MemoryFileRepository()
+        self.extractors = extractors or MemoryExtractorRepository()
+        self.jobs = jobs or MemoryJobRepository()
+        self.providers = providers or MemoryProviderRepository()
+        self.secrets = secrets or MemorySecretStore()
+
+    def __call__(self, *, write: bool = False) -> UnitOfWork:
+        return MemoryUnitOfWork(
+            self.files,
+            self.extractors,
+            self.jobs,
+            self.providers,
+            self.secrets,
+        )
 
 
 class MemoryStorage:
@@ -295,8 +372,45 @@ class StubEngineFactory:
             model=extractor.model or DEFAULT_MODEL,
         )
 
-    def for_extractor(self, extractor: Extractor) -> StubEngine:
+    def for_extractor(
+        self,
+        extractor: Extractor,
+        *,
+        provider: Provider | None = None,
+        api_key: str | None = None,
+    ) -> StubEngine:
         return self.engine
+
+
+def build_memory_uow(
+    files: MemoryFileRepository,
+    extractors: MemoryExtractorRepository,
+    jobs: MemoryJobRepository,
+    *,
+    providers: MemoryProviderRepository | None = None,
+    secrets: MemorySecretStore | None = None,
+) -> MemoryUnitOfWorkFactory:
+    return MemoryUnitOfWorkFactory(
+        files=files,
+        extractors=extractors,
+        jobs=jobs,
+        providers=providers,
+        secrets=secrets,
+    )
+
+
+def build_job_service(
+    jobs: MemoryJobRepository,
+    files: MemoryFileRepository,
+    extractors: MemoryExtractorRepository,
+    storage: MemoryStorage,
+    engine_factory: StubEngineFactory,
+) -> JobService:
+    return JobService(
+        build_memory_uow(files, extractors, jobs),
+        storage,
+        engine_factory,
+    )
 
 
 @pytest.fixture
@@ -306,15 +420,17 @@ def services():
     jobs = MemoryJobRepository()
     storage = MemoryStorage()
     engine = StubEngine(response=ExtractionResponse(data={"receipt_id": "2"}))
+    uow = build_memory_uow(files, extractors, jobs)
     return {
         "files": files,
         "extractors": extractors,
         "jobs": jobs,
         "storage": storage,
         "engine": engine,
-        "file_service": FileService(files, storage),
-        "extractor_service": ExtractorService(extractors, files, default_model=DEFAULT_MODEL),
-        "job_service": JobService(jobs, files, extractors, storage, StubEngineFactory(engine)),
+        "uow": uow,
+        "file_service": FileService(uow, storage),
+        "extractor_service": ExtractorService(uow, default_model=DEFAULT_MODEL),
+        "job_service": JobService(uow, storage, StubEngineFactory(engine)),
     }
 
 
@@ -374,6 +490,31 @@ def test_file_service_rejects_deleting_example_files(services) -> None:
     assert file_service.get(file.id) == file
 
 
+def test_parent_resources_cannot_delete_jobs_implicitly(services) -> None:
+    file = services["file_service"].upload(
+        file_name="a.md", content_type="text/markdown", content=b"Receipt #2"
+    )
+    extractor = services["extractor_service"].create(
+        name="receipt", instructions="extract", schema=schema()
+    )
+    job = services["job_service"].create(extractor_id=extractor.id, file_id=file.id)
+
+    with pytest.raises(ValidationFailure, match="file is referenced by jobs"):
+        services["file_service"].delete(file.id)
+    with pytest.raises(ValidationFailure, match="extractor is referenced by jobs"):
+        services["extractor_service"].delete(extractor.id)
+
+    assert services["job_service"].get(job.id) == job
+    assert services["storage"].deleted == []
+
+    assert services["job_service"].delete(job.id) == DeleteJobResult.DELETED
+    services["file_service"].delete(file.id)
+    services["extractor_service"].delete(extractor.id)
+
+    with pytest.raises(NotFoundError):
+        services["job_service"].get(job.id)
+
+
 def test_file_service_rejects_empty_filename(services) -> None:
     with pytest.raises(ValidationFailure):
         services["file_service"].upload(file_name="", content_type="", content=b"")
@@ -384,6 +525,21 @@ def test_file_service_rejects_unsupported_file_type(services) -> None:
         services["file_service"].upload(
             file_name="a.eml", content_type="message/rfc822", content=b""
         )
+
+
+def test_file_service_removes_written_content_when_persistence_fails(services) -> None:
+    def fail_save(file: File) -> None:
+        raise RuntimeError("database failed")
+
+    services["files"].save = fail_save
+
+    with pytest.raises(RuntimeError, match="database failed"):
+        services["file_service"].upload(
+            file_name="a.md", content_type="text/markdown", content=b"hello"
+        )
+
+    assert len(services["storage"].deleted) == 1
+    assert services["storage"].contents == {}
 
 
 def test_extractor_service_create_update_list_delete(services) -> None:
@@ -825,7 +981,7 @@ def test_job_service_delete_retries_when_queued_delete_loses_race(services) -> N
     running = job.mark_running()
     job_repo = RacingDeleteJobRepository(replacement=running)
     job_repo.save(job)
-    job_service = JobService(
+    job_service = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -867,7 +1023,7 @@ def test_job_service_cancel_rechecks_when_status_transition_loses_race(services)
     completed = job.mark_running().mark_completed(JobResult(data={"receipt_id": "2"}))
     job_repo = RejectingJobRepository(replacement=completed)
     job_repo.save(job)
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -884,7 +1040,7 @@ def test_job_service_cancels_when_job_is_already_canceling_before_engine_extract
 ) -> None:
     job_repo = ControlledJobRepository(status_to_apply=JobStatus.CANCELING)
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -909,7 +1065,7 @@ def test_job_service_cancels_when_job_is_already_canceling_before_engine_extract
 def test_job_service_deletes_when_job_is_deleting_before_engine_extract(services) -> None:
     job_repo = ControlledJobRepository(status_to_apply=JobStatus.DELETING)
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -943,7 +1099,7 @@ def test_job_service_returns_latest_when_execution_config_save_loses_race(servic
     replacement = running.mark_completed(JobResult(data={"receipt_id": "2"}))
     job_repo = RejectingJobRepository(replacement=replacement)
     job_repo.save(running)
-    job_service = JobService(
+    job_service = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -972,8 +1128,9 @@ def test_job_service_cancels_when_job_is_canceling_after_execution_config_save(
 
     storage = CancelingStorage()
     services["storage"] = storage
-    services["file_service"] = FileService(services["files"], storage)
-    services["job_service"] = JobService(
+    storage_uow = build_memory_uow(services["files"], services["extractors"], services["jobs"])
+    services["file_service"] = FileService(storage_uow, storage)
+    services["job_service"] = build_job_service(
         services["jobs"],
         services["files"],
         services["extractors"],
@@ -1071,7 +1228,7 @@ def test_job_service_cancels_when_final_save_loses_race_to_canceling(services) -
         rejected_statuses={JobStatus.COMPLETED},
     )
     job_repo.save(running)
-    job_service = JobService(
+    job_service = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1090,7 +1247,7 @@ def test_job_service_cancels_when_job_becomes_canceling_after_extraction(
     job_repo = ControlledJobRepository(complete_status_to_apply=JobStatus.CANCELING)
 
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1128,7 +1285,7 @@ def test_job_service_cancels_when_job_becomes_canceling_before_saving_completed(
 ) -> None:
     job_repo = MemoryJobRepository()
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1169,7 +1326,7 @@ def test_job_service_deletes_when_job_becomes_deleting_before_saving_completed(
 ) -> None:
     job_repo = MemoryJobRepository()
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1233,7 +1390,7 @@ def test_job_service_cancels_when_engine_raises_cancelled_and_job_is_canceling(
 ) -> None:
     job_repo = ControlledJobRepository(status_to_apply=JobStatus.CANCELING)
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1259,7 +1416,7 @@ def test_job_service_cancels_when_canceling_before_extraction_cancelled_handler(
 ) -> None:
     job_repo = MemoryJobRepository()
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1300,7 +1457,7 @@ def test_job_service_returns_already_canceled_job_when_engine_raises_cancelled(
 ) -> None:
     job_repo = ControlledJobRepository(status_to_apply=JobStatus.CANCELED, preserve_canceled=True)
     services["jobs"] = job_repo
-    services["job_service"] = JobService(
+    services["job_service"] = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1400,7 +1557,7 @@ def test_cancel_if_requested_returns_latest_when_finalize_loses_race(services) -
     canceling = job.mark_running().mark_canceling()
     job_repo = RejectingJobRepository(replacement=canceling)
     job_repo.save(canceling)
-    job_service = JobService(
+    job_service = build_job_service(
         job_repo,
         services["files"],
         services["extractors"],
@@ -1585,6 +1742,21 @@ def test_job_service_engine_exception_fails_job(services) -> None:
     assert "model unavailable" in completed.error.message
 
 
+def test_job_service_does_not_convert_persistence_contention_into_job_failure(
+    services,
+) -> None:
+    services["engine"].error = PersistenceBusyError()
+    file = services["file_service"].upload(file_name="a.md", content_type="", content=b"x")
+    extractor = services["extractor_service"].create(name="e", instructions="i", schema=schema())
+    job = services["job_service"].create(extractor_id=extractor.id, file_id=file.id)
+
+    with pytest.raises(PersistenceBusyError):
+        services["job_service"].run_claimed(job)
+
+    persisted = services["job_service"].get(job.id)
+    assert persisted.status == JobStatus.RUNNING
+
+
 def test_job_service_missing_resources_during_run_fail_job(services) -> None:
     job = Job(
         id="job_1",
@@ -1703,7 +1875,8 @@ def _provider_service() -> tuple[ProviderService, MemoryProviderRepository, Memo
     providers.save(
         Provider(name=ProviderName.OPENAI_COMPATIBLE, base_url="http://127.0.0.1:8080/v1")
     )
-    return ProviderService(providers, secrets), providers, secrets
+    uow = MemoryUnitOfWorkFactory(providers=providers, secrets=secrets)
+    return ProviderService(uow), providers, secrets
 
 
 def test_provider_service_list_get_and_missing() -> None:

--- a/tests/unit/server/test_container.py
+++ b/tests/unit/server/test_container.py
@@ -57,9 +57,13 @@ def test_factory_builds_engine_from_provider_config_and_key() -> None:
         [Provider(name=ProviderName.OPENAI, base_url="https://api.openai.com/v1")]
     )
     secrets = _Secrets({ProviderName.OPENAI: "sk-x"})
-    factory = EngineFactory(providers, secrets, Settings())
+    factory = EngineFactory(Settings())
 
-    engine = factory.for_extractor(_extractor(ProviderName.OPENAI, "gpt-4o-mini"))
+    engine = factory.for_extractor(
+        _extractor(ProviderName.OPENAI, "gpt-4o-mini"),
+        provider=providers.get(ProviderName.OPENAI),
+        api_key=secrets.get(ProviderName.OPENAI),
+    )
 
     assert isinstance(engine, OpenAIExtractionEngine)
     assert engine._config.base_url == "https://api.openai.com/v1"
@@ -73,10 +77,13 @@ def test_factory_defaults_provider_and_uses_empty_key_for_local_runtime() -> Non
         [Provider(name=ProviderName.OPENAI_COMPATIBLE, base_url="http://127.0.0.1:8080/v1")]
     )
     settings = Settings()
-    factory = EngineFactory(providers, _Secrets(), settings)
+    factory = EngineFactory(settings)
 
     resolved = factory.resolve_extractor_config(_extractor())
-    engine = factory.for_extractor(_extractor())  # no provider/model -> defaults
+    engine = factory.for_extractor(
+        _extractor(),
+        provider=providers.get(ProviderName.OPENAI_COMPATIBLE),
+    )  # no provider/model -> defaults
 
     assert resolved.provider_name == ProviderName.OPENAI_COMPATIBLE
     assert resolved.model == settings.vllm_model
@@ -91,14 +98,27 @@ def test_factory_caches_by_config_and_refreshes_on_key_change() -> None:
         [Provider(name=ProviderName.OPENAI, base_url="https://api.openai.com/v1")]
     )
     secrets = _Secrets({ProviderName.OPENAI: "sk-1"})
-    factory = EngineFactory(providers, secrets, Settings())
+    factory = EngineFactory(Settings())
     extractor = _extractor(ProviderName.OPENAI, "gpt-4o-mini")
+    provider = providers.get(ProviderName.OPENAI)
 
-    first = factory.for_extractor(extractor)
-    assert factory.for_extractor(extractor) is first
+    first = factory.for_extractor(
+        extractor, provider=provider, api_key=secrets.get(ProviderName.OPENAI)
+    )
+    assert (
+        factory.for_extractor(
+            extractor, provider=provider, api_key=secrets.get(ProviderName.OPENAI)
+        )
+        is first
+    )
 
     secrets.put(ProviderName.OPENAI, "sk-2")
-    assert factory.for_extractor(extractor) is not first
+    assert (
+        factory.for_extractor(
+            extractor, provider=provider, api_key=secrets.get(ProviderName.OPENAI)
+        )
+        is not first
+    )
 
 
 def test_container_wires_services_and_leaves_local_model_inherited(tmp_path: Path) -> None:

--- a/tests/unit/server/test_migrations.py
+++ b/tests/unit/server/test_migrations.py
@@ -31,6 +31,7 @@ INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID = (
 )
 JOB_EXECUTION_MODEL_METADATA_ID = "20260708133000_job_execution_model_metadata"
 EXTRACTOR_REASONING_EFFORT_ID = "20260709090000_extractor_reasoning_effort"
+RESTRICT_JOB_PARENT_DELETION_ID = "20260721120000_restrict_job_parent_deletion"
 ALL_MIGRATION_IDS = [
     BASELINE_ID,
     ADD_PROVIDERS_ID,
@@ -40,6 +41,7 @@ ALL_MIGRATION_IDS = [
     INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
     JOB_EXECUTION_MODEL_METADATA_ID,
     EXTRACTOR_REASONING_EFFORT_ID,
+    RESTRICT_JOB_PARENT_DELETION_ID,
 ]
 
 # The full current schema after all migrations. ALTER-added columns
@@ -132,8 +134,8 @@ def test_baseline_applied_to_fresh_db_matches_current_schema(conn: sqlite3.Conne
     }
     assert "idx_extractors_name" in indexes(conn, "extractors")
     assert foreign_keys(conn, "jobs") == {
-        ("file_id", "files", "id", "CASCADE"),
-        ("extractor_id", "extractors", "id", "CASCADE"),
+        ("file_id", "files", "id", "RESTRICT"),
+        ("extractor_id", "extractors", "id", "RESTRICT"),
     }
 
 
@@ -145,6 +147,61 @@ def test_apply_pending_is_idempotent(conn: sqlite3.Connection) -> None:
     status = migration_status(conn)
     assert status.applied == ALL_MIGRATION_IDS
     assert status.pending == []
+
+
+def test_restrict_parent_deletion_migration_preserves_existing_jobs(
+    conn: sqlite3.Connection,
+) -> None:
+    _register_functions(conn)
+    earlier_ids = ALL_MIGRATION_IDS[:-1]
+    for migration_id in earlier_ids:
+        migration = next(
+            migration for migration in discover_migrations() if migration.id == migration_id
+        )
+        conn.executescript(migration.path.read_text(encoding="utf-8"))
+    conn.execute("CREATE TABLE schema_migrations (id TEXT PRIMARY KEY, applied_at TEXT NOT NULL)")
+    conn.executemany(
+        "INSERT INTO schema_migrations (id, applied_at) VALUES (?, ?)",
+        [(migration_id, "t") for migration_id in earlier_ids],
+    )
+    conn.execute(
+        """
+        INSERT INTO files (
+            id, file_name, content_type, size_bytes, sha256, storage_path,
+            source, seed_key, seed_version, created_at
+        ) VALUES ('file_1', 'a.md', 'text/markdown', 1, 'x', 'files/a.md',
+                  'user', NULL, NULL, 't')
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO extractors (
+            id, name, display_name, instructions, schema, examples, source,
+            seed_key, seed_version, created_at, updated_at, provider_name,
+            model, reasoning_effort
+        ) VALUES ('extractor_1', 'example', 'Example', 'Extract.', '{}', '[]',
+                  'user', NULL, NULL, 't', 't', NULL, NULL, NULL)
+        """
+    )
+    conn.execute(
+        """
+        INSERT INTO jobs (
+            id, extractor_id, file_id, source_text, status, result, error,
+            created_at, started_at, completed_at, provider_name_used, model_used
+        ) VALUES ('job_1', 'extractor_1', 'file_1', NULL, 'queued', NULL, NULL,
+                  't', NULL, NULL, NULL, NULL)
+        """
+    )
+    conn.commit()
+
+    assert apply_pending(conn) == [RESTRICT_JOB_PARENT_DELETION_ID]
+    assert conn.execute("SELECT id FROM jobs").fetchone()["id"] == "job_1"
+
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("DELETE FROM files WHERE id = 'file_1'")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("DELETE FROM extractors WHERE id = 'extractor_1'")
+    assert conn.execute("SELECT id FROM jobs").fetchone()["id"] == "job_1"
 
 
 def test_migration_status_reports_pending_before_apply(conn: sqlite3.Connection) -> None:
@@ -390,6 +447,7 @@ def test_provider_configuration_migration_renames_foundry_without_data_loss(
         INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
         JOB_EXECUTION_MODEL_METADATA_ID,
         EXTRACTOR_REASONING_EFFORT_ID,
+        RESTRICT_JOB_PARENT_DELETION_ID,
     ]
 
     assert columns(conn, "providers") == EXPECTED_COLUMNS["providers"]
@@ -450,6 +508,7 @@ def test_remove_foundry_api_version_config_migration_strips_already_migrated_con
         INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
         JOB_EXECUTION_MODEL_METADATA_ID,
         EXTRACTOR_REASONING_EFFORT_ID,
+        RESTRICT_JOB_PARENT_DELETION_ID,
     ]
 
     provider = conn.execute(
@@ -517,6 +576,7 @@ def test_inherit_openai_compatible_default_model_migration_preserves_custom_mode
         INHERIT_OPENAI_COMPATIBLE_DEFAULT_MODEL_ID,
         JOB_EXECUTION_MODEL_METADATA_ID,
         EXTRACTOR_REASONING_EFFORT_ID,
+        RESTRICT_JOB_PARENT_DELETION_ID,
     ]
 
     models = {
@@ -589,7 +649,10 @@ def test_extractor_reasoning_effort_migration_backfills_per_adapter(
         )
     conn.commit()
 
-    assert apply_pending(conn) == [EXTRACTOR_REASONING_EFFORT_ID]
+    assert apply_pending(conn) == [
+        EXTRACTOR_REASONING_EFFORT_ID,
+        RESTRICT_JOB_PARENT_DELETION_ID,
+    ]
 
     assert "enable_thinking" not in columns(conn, "extractors")
     efforts = {

--- a/tests/unit/server/test_openapi_contract.py
+++ b/tests/unit/server/test_openapi_contract.py
@@ -99,6 +99,9 @@ def test_binary_download_and_common_errors_are_explicit() -> None:
     assert "404" in download["responses"]
     assert "400" in paths["/v1/providers/{name}/models"]["get"]["responses"]
     assert "422" in paths["/v1/schemas/validate"]["post"]["responses"]
+    assert paths["/v1/files/{file_id}"]["delete"]["responses"]["422"]["content"][
+        "application/json"
+    ]["schema"] == {"$ref": "#/components/schemas/ApiErrorResponse"}
 
 
 def test_main_flow_has_executable_curl_samples() -> None:

--- a/tests/unit/server/test_sqlite.py
+++ b/tests/unit/server/test_sqlite.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import sqlite3
+from concurrent.futures import ThreadPoolExecutor
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Iterator
 
 import pytest
 from cryptography.fernet import Fernet
+from sqlalchemy import Connection
+from sqlalchemy.exc import IntegrityError
 
+from parsehawk.core.domain.errors import PersistenceBusyError
 from parsehawk.core.domain.models import (
     Example,
     ExampleInput,
@@ -28,8 +32,11 @@ from parsehawk.server.adapters.persistence.sqlite import (
     SQLiteJobRepository,
     SQLiteProviderRepository,
     SQLiteSecretStore,
+    SQLiteUnitOfWorkFactory,
     connect,
+    create_sqlite_engine,
     init_db,
+    init_engine,
 )
 from parsehawk.server.adapters.security import SecretCipher
 
@@ -42,6 +49,31 @@ def conn(tmp_path: Path) -> Iterator[sqlite3.Connection]:
         yield connection
     finally:
         connection.close()
+
+
+@pytest.fixture
+def sa_conn(tmp_path: Path) -> Iterator[Connection]:
+    engine = create_sqlite_engine(tmp_path / "parsehawk-core.db")
+    init_engine(engine)
+    connection = engine.connect()
+    transaction = connection.begin()
+    try:
+        yield connection
+    finally:
+        transaction.rollback()
+        connection.close()
+        engine.dispose()
+
+
+@pytest.fixture
+def uow_factory(tmp_path: Path) -> Iterator[SQLiteUnitOfWorkFactory]:
+    engine = create_sqlite_engine(tmp_path / "parsehawk-uow.db")
+    init_engine(engine)
+    factory = SQLiteUnitOfWorkFactory(engine, SecretCipher(Fernet.generate_key()))
+    try:
+        yield factory
+    finally:
+        factory.close()
 
 
 def test_init_db_creates_structured_tables_indexes_and_foreign_keys(
@@ -95,15 +127,15 @@ def test_init_db_creates_structured_tables_indexes_and_foreign_keys(
     }
     assert "idx_extractors_name" in indexes(conn, "extractors")
     assert foreign_keys(conn, "jobs") == {
-        ("file_id", "files", "id", "CASCADE"),
-        ("extractor_id", "extractors", "id", "CASCADE"),
+        ("file_id", "files", "id", "RESTRICT"),
+        ("extractor_id", "extractors", "id", "RESTRICT"),
     }
 
 
-def test_repositories_round_trip_domain_models(conn: sqlite3.Connection) -> None:
-    files = SQLiteFileRepository(conn)
-    extractors = SQLiteExtractorRepository(conn)
-    jobs = SQLiteJobRepository(conn)
+def test_repositories_round_trip_domain_models(sa_conn: Connection) -> None:
+    files = SQLiteFileRepository(sa_conn)
+    extractors = SQLiteExtractorRepository(sa_conn)
+    jobs = SQLiteJobRepository(sa_conn)
     file = sample_file()
     extractor = sample_extractor()
     queued = sample_job(file_id=file.id, extractor_id=extractor.id)
@@ -137,8 +169,8 @@ def test_repositories_round_trip_domain_models(conn: sqlite3.Connection) -> None
     assert jobs.list(extractor_id=extractor.id) == [completed, failed]
 
 
-def test_extractor_round_trips_provider_and_model(conn: sqlite3.Connection) -> None:
-    extractors = SQLiteExtractorRepository(conn)
+def test_extractor_round_trips_provider_and_model(sa_conn: Connection) -> None:
+    extractors = SQLiteExtractorRepository(sa_conn)
     extractor = sample_extractor().model_copy(
         update={"provider_name": ProviderName.OPENAI, "model": "gpt-4o-mini"}
     )
@@ -148,8 +180,8 @@ def test_extractor_round_trips_provider_and_model(conn: sqlite3.Connection) -> N
     assert extractors.get(extractor.id) == extractor
 
 
-def test_provider_repository_round_trip_and_upsert(conn: sqlite3.Connection) -> None:
-    providers = SQLiteProviderRepository(conn)
+def test_provider_repository_round_trip_and_upsert(sa_conn: Connection) -> None:
+    providers = SQLiteProviderRepository(sa_conn)
     provider = Provider(
         name=ProviderName.OPENAI_COMPATIBLE,
         base_url="http://127.0.0.1:8080/v1",
@@ -177,10 +209,10 @@ def test_provider_repository_round_trip_and_upsert(conn: sqlite3.Connection) -> 
     assert stored.created_at == provider.created_at
 
 
-def test_secret_store_encrypts_and_round_trips(conn: sqlite3.Connection) -> None:
-    providers = SQLiteProviderRepository(conn)
+def test_secret_store_encrypts_and_round_trips(sa_conn: Connection) -> None:
+    providers = SQLiteProviderRepository(sa_conn)
     providers.save(Provider(name=ProviderName.OPENAI))  # FK target for the secret
-    secrets = SQLiteSecretStore(conn, SecretCipher(Fernet.generate_key()))
+    secrets = SQLiteSecretStore(sa_conn, SecretCipher(Fernet.generate_key()))
 
     assert secrets.has(ProviderName.OPENAI) is False
     assert secrets.get(ProviderName.OPENAI) is None
@@ -189,9 +221,13 @@ def test_secret_store_encrypts_and_round_trips(conn: sqlite3.Connection) -> None
 
     assert secrets.has(ProviderName.OPENAI) is True
     assert secrets.get(ProviderName.OPENAI) == "sk-secret"
-    ciphertext = conn.execute(
-        "SELECT ciphertext FROM provider_secrets WHERE provider_name = ?", ("openai",)
-    ).fetchone()["ciphertext"]
+    ciphertext = (
+        sa_conn.exec_driver_sql(
+            "SELECT ciphertext FROM provider_secrets WHERE provider_name = ?", ("openai",)
+        )
+        .mappings()
+        .one()["ciphertext"]
+    )
     assert ciphertext != "sk-secret"
 
     secrets.put(ProviderName.OPENAI, "sk-rotated")  # upsert replaces the ciphertext
@@ -201,10 +237,10 @@ def test_secret_store_encrypts_and_round_trips(conn: sqlite3.Connection) -> None
     assert secrets.has(ProviderName.OPENAI) is False
 
 
-def test_claim_next_queued_marks_oldest_job_running(conn: sqlite3.Connection) -> None:
-    files = SQLiteFileRepository(conn)
-    extractors = SQLiteExtractorRepository(conn)
-    jobs = SQLiteJobRepository(conn)
+def test_claim_next_queued_marks_oldest_job_running(sa_conn: Connection) -> None:
+    files = SQLiteFileRepository(sa_conn)
+    extractors = SQLiteExtractorRepository(sa_conn)
+    jobs = SQLiteJobRepository(sa_conn)
     file = sample_file()
     extractor = sample_extractor()
     newest = sample_job(id="job_newest", file_id=file.id, extractor_id=extractor.id)
@@ -225,10 +261,10 @@ def test_claim_next_queued_marks_oldest_job_running(conn: sqlite3.Connection) ->
     assert jobs.get(newest.id) == newest
 
 
-def test_save_if_status_refuses_stale_job_transition(conn: sqlite3.Connection) -> None:
-    files = SQLiteFileRepository(conn)
-    extractors = SQLiteExtractorRepository(conn)
-    jobs = SQLiteJobRepository(conn)
+def test_save_if_status_refuses_stale_job_transition(sa_conn: Connection) -> None:
+    files = SQLiteFileRepository(sa_conn)
+    extractors = SQLiteExtractorRepository(sa_conn)
+    jobs = SQLiteJobRepository(sa_conn)
     file = sample_file()
     extractor = sample_extractor()
     running = sample_job(file_id=file.id, extractor_id=extractor.id).mark_running()
@@ -247,10 +283,10 @@ def test_save_if_status_refuses_stale_job_transition(conn: sqlite3.Connection) -
     assert stored.status == JobStatus.CANCELING
 
 
-def test_delete_if_status_refuses_stale_job_delete(conn: sqlite3.Connection) -> None:
-    files = SQLiteFileRepository(conn)
-    extractors = SQLiteExtractorRepository(conn)
-    jobs = SQLiteJobRepository(conn)
+def test_delete_if_status_refuses_stale_job_delete(sa_conn: Connection) -> None:
+    files = SQLiteFileRepository(sa_conn)
+    extractors = SQLiteExtractorRepository(sa_conn)
+    jobs = SQLiteJobRepository(sa_conn)
     file = sample_file()
     extractor = sample_extractor()
     running = sample_job(file_id=file.id, extractor_id=extractor.id).mark_running()
@@ -269,10 +305,10 @@ def test_delete_if_status_refuses_stale_job_delete(conn: sqlite3.Connection) -> 
     assert jobs.get(running.id) is None
 
 
-def test_deleting_file_or_extractor_cascades_jobs(conn: sqlite3.Connection) -> None:
-    files = SQLiteFileRepository(conn)
-    extractors = SQLiteExtractorRepository(conn)
-    jobs = SQLiteJobRepository(conn)
+def test_deleting_referenced_file_or_extractor_is_restricted(sa_conn: Connection) -> None:
+    files = SQLiteFileRepository(sa_conn)
+    extractors = SQLiteExtractorRepository(sa_conn)
+    jobs = SQLiteJobRepository(sa_conn)
     file = sample_file()
     extractor = sample_extractor()
     other_extractor = sample_extractor(id="extractor_other")
@@ -286,21 +322,23 @@ def test_deleting_file_or_extractor_cascades_jobs(conn: sqlite3.Connection) -> N
     jobs.save(text_job)
     jobs.save(other_job)
 
-    files.delete(file.id)
+    with pytest.raises(IntegrityError):
+        files.delete(file.id)
 
-    assert jobs.get(file_job.id) is None
-    assert jobs.get(other_job.id) is None
+    assert jobs.get(file_job.id) == file_job
+    assert jobs.get(other_job.id) == other_job
     assert jobs.get(text_job.id) == text_job
 
-    extractors.delete(extractor.id)
+    with pytest.raises(IntegrityError):
+        extractors.delete(extractor.id)
 
-    assert jobs.get(text_job.id) is None
+    assert jobs.get(text_job.id) == text_job
 
 
-def test_updating_file_or_extractor_does_not_cascade_jobs(conn: sqlite3.Connection) -> None:
-    files = SQLiteFileRepository(conn)
-    extractors = SQLiteExtractorRepository(conn)
-    jobs = SQLiteJobRepository(conn)
+def test_updating_file_or_extractor_preserves_jobs(sa_conn: Connection) -> None:
+    files = SQLiteFileRepository(sa_conn)
+    extractors = SQLiteExtractorRepository(sa_conn)
+    jobs = SQLiteJobRepository(sa_conn)
     file = sample_file()
     extractor = sample_extractor()
     job = sample_job(file_id=file.id, extractor_id=extractor.id)
@@ -312,6 +350,78 @@ def test_updating_file_or_extractor_does_not_cascade_jobs(conn: sqlite3.Connecti
     extractors.save(extractor.model_copy(update={"name": "Updated"}))
 
     assert jobs.get(job.id) == job
+
+
+@pytest.mark.concurrency
+def test_unit_of_work_isolates_and_rolls_back_uncommitted_writes(
+    uow_factory: SQLiteUnitOfWorkFactory,
+) -> None:
+    provider = Provider(name=ProviderName.OPENAI)
+
+    with uow_factory(write=True) as writer:
+        writer.providers.save(provider)
+        with uow_factory() as reader:
+            assert reader.providers.get(ProviderName.OPENAI) is None
+
+    with uow_factory() as reader:
+        assert reader.providers.get(ProviderName.OPENAI) is None
+
+    with uow_factory(write=True) as writer:
+        writer.providers.save(provider)
+        writer.commit()
+
+    with uow_factory() as reader:
+        assert reader.providers.get(ProviderName.OPENAI) == provider
+
+
+@pytest.mark.concurrency
+def test_unit_of_work_translates_exhausted_write_contention(tmp_path: Path) -> None:
+    engine = create_sqlite_engine(tmp_path / "busy.db", busy_timeout_ms=25)
+    init_engine(engine)
+    factory = SQLiteUnitOfWorkFactory(engine, SecretCipher(Fernet.generate_key()))
+    try:
+        with factory(write=True):
+            with pytest.raises(PersistenceBusyError) as error:
+                with factory(write=True):
+                    pass
+        assert error.value.code == "persistence_busy"
+        assert error.value.retryable is True
+    finally:
+        factory.close()
+
+
+@pytest.mark.concurrency
+def test_concurrent_claimers_never_claim_the_same_job(
+    uow_factory: SQLiteUnitOfWorkFactory,
+) -> None:
+    file = sample_file()
+    extractor = sample_extractor()
+    jobs = [
+        sample_job(id=f"job_{index}", file_id=file.id, extractor_id=extractor.id).model_copy(
+            update={"created_at": datetime(2024, 1, index + 1, tzinfo=UTC)}
+        )
+        for index in range(10)
+    ]
+    with uow_factory(write=True) as uow:
+        uow.files.save(file)
+        uow.extractors.save(extractor)
+        for job in jobs:
+            uow.jobs.save(job)
+        uow.commit()
+
+    def claim_one() -> str | None:
+        with uow_factory(write=True) as uow:
+            claimed = uow.jobs.claim_next_queued()
+            uow.commit()
+            return claimed.id if claimed else None
+
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        claimed_ids = list(executor.map(lambda _: claim_one(), range(len(jobs))))
+
+    assert None not in claimed_ids
+    assert len(set(claimed_ids)) == len(jobs)
+    assert set(claimed_ids) == {job.id for job in jobs}
+    assert claim_one() is None
 
 
 def columns(conn: sqlite3.Connection, table: str) -> list[str]:

--- a/uv.lock
+++ b/uv.lock
@@ -310,6 +310,30 @@ wheels = [
 ]
 
 [[package]]
+name = "greenlet"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/f1/fbbfef6af0bad0548f09bc28948ea3c275b4edb19e17fc5ca9900a6a634d/greenlet-3.5.3.tar.gz", hash = "sha256:a61efc018fd3eb317eeca31aba90ee9e7f26f22884a79b6c6ec715bf71bb62f1", size = 200270, upload-time = "2026-06-26T19:28:24.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/58/5404031044f55afad7aad1aff8be3f22b1bed03e237cfeabbc7e5c8cfde0/greenlet-3.5.3-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:aca9b4ce85b152b5524ef7d88170efdff80dc0032aa8b75f9aaf7f3479ea95b4", size = 287424, upload-time = "2026-06-26T18:20:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/bf/1c65e9b94a54d547068fa5b5a8a06f221f3316b48908e08668d29c77cb50/greenlet-3.5.3-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f71be4920368fe1fabeeaa53d1e3548337e2b223d9565f8ad5e392a75ba23fc", size = 606523, upload-time = "2026-06-26T19:07:08.859Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/b66baacc95775ad511287acb0137b95574a9ce5491902372b7564799d790/greenlet-3.5.3-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4d77e67f65f98449e3fb83f795b5d0a8437aead2f874ca89c96576caf4be3af6", size = 618315, upload-time = "2026-06-26T19:10:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2b/28ed29463522fdbe4c15b1f63922041626a7478316b34ab4adda3f0a4aba/greenlet-3.5.3-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8540f1e6205bd13ca0ce685581037219ca54a1b41a0a15d228c6c9b8ad5903d7", size = 617381, upload-time = "2026-06-26T18:32:16.077Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/7b/ad04e9d1337fc04965dc9fc616b6a72cb65a24b800a014c011ec812f5489/greenlet-3.5.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7ef56fe650f50575bf843acde967b9c567687f3c22340941a899b7bc56e956a8", size = 1577771, upload-time = "2026-06-26T19:09:01.537Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/33/6c87ab7ba663f70ca21f3022aad1ffe56d3f3e0521e836c2415e13abcc3c/greenlet-3.5.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5121af01cf911e70056c00d4b46d5e9b5d1415550038573d744138bacb59e6b8", size = 1644048, upload-time = "2026-06-26T18:31:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/35/f0d8ee998b422cf8693b270f098e55d8d4ec8006b061b333f54f177d28d9/greenlet-3.5.3-cp311-cp311-win_amd64.whl", hash = "sha256:0f41e4a05a3c0cb31b17023eff28dd111e1d16bf7d7d00406cd7df23f31398a7", size = 239137, upload-time = "2026-06-26T18:23:21.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/96/b9820295576ef18c9edc404f10e260ae7215ceaf3781a54b720ed2627862/greenlet-3.5.3-cp311-cp311-win_arm64.whl", hash = "sha256:ec6f1af59f6b5f3fc9678e2ea062d8377d22ac644f7844cb7a292910cf12ff44", size = 237630, upload-time = "2026-06-26T18:24:00.281Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
+    { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/6fea0e3d6600f785069481ee637e09378dd4118acdfd38ad88ae2db31c98/greenlet-3.5.3-cp312-cp312-win_arm64.whl", hash = "sha256:c4e7b79d83805475f0102008843f6eb45fd3bb0b2e88c774adab5fbaab27117d", size = 238211, upload-time = "2026-06-26T18:22:37.671Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -726,6 +750,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pypdfium2" },
     { name = "python-multipart" },
+    { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -763,6 +788,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pypdfium2", specifier = ">=5.10.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["tracing"]
@@ -1242,6 +1268,33 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/f1/a7a892f18d4d224e6b26f706531eafccc41e37594d37d304786969ee13cb/sqlalchemy-2.0.51.tar.gz", hash = "sha256:804dccd8a4a6242c4e30ad961e540e18a588f6527202f2d6791b01845d59fdc9", size = 9912201, upload-time = "2026-06-15T15:41:20.012Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/69/a67c69e5f28fc9c99d6f7bd60bd50e91f2fed2423e3b30fb228fa00e51f3/sqlalchemy-2.0.51-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1aa10c0daee6705294d181daadaa793221e1a59ed55000a3fab1d42b088ce4ba", size = 2161838, upload-time = "2026-06-15T16:05:17.144Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a4/c8c22b8438bddc0a030157c6ec0f6ef97b3c38effa444bdab2a27af04090/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a5b2ed6d828f1f09bd812861f4f59ca3bc3803f9df871f4555187f0faf018604", size = 3319402, upload-time = "2026-06-15T16:10:40.002Z" },
+    { url = "https://files.pythonhosted.org/packages/90/54/44012d32fd77d991256d2ff793ba3807c51d40cb27a85b4796224f6744df/sqlalchemy-2.0.51-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:436728ce18a80f6951a1e11cc6112c2ede9faf20766f1a26195a7c441ca12dbd", size = 3319675, upload-time = "2026-06-15T16:12:25.658Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a5/de0592acaf5906cd7430874392d6f7e8b4a7c8437610953ee2d1501c0b44/sqlalchemy-2.0.51-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dc261707bf5739aea8a541593f3cc1d463c2701fb05fbcbba0ce031b69a21260", size = 3270777, upload-time = "2026-06-15T16:10:42.125Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/14/a44c90739c780b362238e4ac3cb19dd0ca40d13e6ddc5daa112166ddab4f/sqlalchemy-2.0.51-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a6d26094615306d116dd5e4a51b0304c99dd2356fc569eed6922a80a6bd3b265", size = 3293940, upload-time = "2026-06-15T16:12:27.156Z" },
+    { url = "https://files.pythonhosted.org/packages/65/eb/fbd0f206a330e66f8c602a99c37c4e731f107faed62954b41b01f16dd9d9/sqlalchemy-2.0.51-cp311-cp311-win32.whl", hash = "sha256:ca8435d13829b92f4a97362d91975154a4015db3a2634154e1754e9a915e6b86", size = 2121183, upload-time = "2026-06-15T16:13:29.905Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fd/005bf80f3cf6e5c62b5dd68616280f51cd012c60840fa74781b3ed7b1623/sqlalchemy-2.0.51-cp311-cp311-win_amd64.whl", hash = "sha256:4a011ea4510683319ce4ed274b56ee05194b39b6da9d09ca7a39388f0fa84dcc", size = 2145796, upload-time = "2026-06-15T16:13:31.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/70/e868bc5412acd101a8280f25c95f10eeae0771c4eb806b02491142810ee8/sqlalchemy-2.0.51-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d78702b26ba1c18b2d0fb2ea940ba7f17a9581b42e8361ff93920ebbee1235a", size = 2160291, upload-time = "2026-06-15T16:08:48.918Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/1c/71ee0f8a6b9d7316a1ccd30430b4c62b6c2e36adc96017a4e3a72dce49d6/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581921d849d6e6f994d560389192955e80e2950e18fcdfe2ccea863e01158e6e", size = 3343835, upload-time = "2026-06-15T16:19:42.613Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7c/7ab9f9aadc5944fdd06612484ed7918fe376ad871a5f50404dc1536e0194/sqlalchemy-2.0.51-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1d21ce524ab86c23046e992a5b81cb54c21079c6df6e78b8fc77d77cac70a6b9", size = 3358470, upload-time = "2026-06-15T16:26:38.011Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7d/ff77169fee6186de145a7f2b87006c39638391130abbab2b1f63ac6ea583/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c5d98a2709840027f5a347c3af0a7c3d5f6c1ff93af2ca1c54494e23cba8f389", size = 3289874, upload-time = "2026-06-15T16:19:45.212Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/3b/6c505903710d781b55bc3141ee34a062bf9745a6b5bc7333305b9ed63b33/sqlalchemy-2.0.51-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1181256e0f16479691b5616d36375dc2620ad8332b25978763c3d206ad3f3f1d", size = 3321692, upload-time = "2026-06-15T16:26:39.747Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b7/c5ffe50aa2f4d947c9250e1519d939260329a07fe6272edfccd784b3d007/sqlalchemy-2.0.51-cp312-cp312-win32.whl", hash = "sha256:9f380393be5abeb6815f68fd39271b95127173511b6706b0a630a9995d53f8f5", size = 2119674, upload-time = "2026-06-15T16:23:09.543Z" },
+    { url = "https://files.pythonhosted.org/packages/25/dc/46a65916af68a06ef6b972c6050ba4c8f97070fe3fb33097d34229d9bef6/sqlalchemy-2.0.51-cp312-cp312-win_amd64.whl", hash = "sha256:2cf39aabdf48e87c1c2c2ed6d20d33ffa0733b3071ce9c5f66357947dd009080", size = 2146670, upload-time = "2026-06-15T16:23:11.048Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/22/dbf013a12ec759e54a34a119e9e217435b3f71b2dd5c61a7ade0a25dae87/sqlalchemy-2.0.51-py3-none-any.whl", hash = "sha256:bb024d8b621d0be75f4f44ecc7c950450026e76d66dc8f791bb5331d7fed59d5", size = 1944334, upload-time = "2026-06-15T16:09:22.418Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- replace the process-shared `sqlite3` connection with synchronous SQLAlchemy Core engines and application-owned Units of Work
- keep worker file preparation and model calls outside database transactions, preserve conditional status transitions, and map exhausted lock contention to retryable HTTP 503 responses
- retry post-claim persistence phases without rerunning inference, and keep local file deletion recoverable when storage cleanup fails
- migrate job parent foreign keys from cascading deletion to restricted deletion, and publish the file-delete 422 contract
- document the supported SQLite concurrency envelope

## Verification

- `just check` (355 passed, 18 deselected, 100% core coverage)
- `just test-concurrency` (7 passed)
- OpenAPI validation (0 errors, 0 warnings)
- web tests (34 passed), typecheck, and production build
- restarted the complete Docker stack with the NuExtract3 Metal runtime
- `just e2e` (18 passed in 43.05s)

Closes #132
