### PR TITLE
Fix enum choice whitespace editing

### DIFF
--- a/apps/web/src/App.test.tsx
+++ b/apps/web/src/App.test.tsx
@@ -351,6 +351,26 @@ describe("App run workflow", () => {
     });
   });
 
+  it("allows spaces and new lines while editing enum choices", async () => {
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+      const url = String(input);
+      if (url === "/v1/files" || url === "/v1/extractors") {
+        return jsonResponse([]);
+      }
+      return jsonResponse({ detail: "unexpected request" }, { status: 500 });
+    });
+
+    render(<App />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "New" }));
+    await userEvent.click(screen.getByRole("button", { name: "Add field" }));
+
+    const enumValues = screen.getByLabelText("Enum values");
+    await userEvent.type(enumValues, "Pending review{enter}Needs follow up");
+
+    expect(enumValues).toHaveValue("Pending review\nNeeds follow up");
+  });
+
   it("does not infer examples from receipt-like user records and resets edited extractors", async () => {
     vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
       const url = String(input);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2002,10 +2002,7 @@ function normalizeSchemaField(schemaField: SchemaField): SchemaField {
 }
 
 function enumValuesFromEditorText(value: string): string[] {
-  return value
-    .split(/\r?\n/)
-    .map((item) => item.trim())
-    .filter(Boolean);
+  return value === "" ? [] : value.split(/\r?\n/);
 }
 
 function pastedCommaSeparatedEnumValues(event: ClipboardEvent<HTMLTextAreaElement>): string[] {


### PR DESCRIPTION
## Summary

- Preserve spaces and trailing newlines while editing enum choices in the schema builder.
- Keep existing enum normalization at the schema serialization boundary.
- Add a UI regression test for multi-word enum choices entered on separate lines.

## Root cause

The enum textarea is controlled by `field.enumValues`. Its `onChange` handler trimmed every line and filtered blank lines before updating state, then the rendered value joined that normalized array again. Each controlled rerender therefore removed a newly typed space or trailing newline before the next keystroke.

## Validation

- `pnpm --dir apps/web test` - 35 tests passed
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web build`
- Repository pre-commit hooks, including unit tests, Web tests, Web typecheck, Ruff, and ty
- `git diff --check`

Closes #121
