### PR TITLE
fix(deps): force postcss to a patched release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   form-data: '>=4.0.6'
   hono: '>=4.12.27'
   js-yaml: ^4.3.0
+  postcss: '>=8.5.18'
 
 importers:
 
@@ -3867,8 +3868,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.14:
-    resolution: {integrity: sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4088,7 +4089,7 @@ packages:
     resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: '>=8.5.18'
 
   postcss-selector-parser@6.1.4:
     resolution: {integrity: sha512-bIoJLOmjCO1S9XdY/DcnR5hJxvrDir1PbGChrzXG3vw0/FOliy/fA3dmdhQ441kah4gKv+TwckGzex6wNS5cnQ==}
@@ -4098,12 +4099,8 @@ packages:
     resolution: {integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==}
     engines: {node: '>=4'}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.16:
-    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -5940,8 +5937,8 @@ snapshots:
       hast-util-to-html: 9.0.5
       hast-util-to-text: 4.0.2
       hastscript: 9.0.1
-      postcss: 8.5.16
-      postcss-nested: 6.2.0(postcss@8.5.16)
+      postcss: 8.5.23
+      postcss-nested: 6.2.0(postcss@8.5.23)
       unist-util-visit: 5.1.0
       unist-util-visit-parents: 6.0.2
 
@@ -9443,7 +9440,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.14: {}
+  nanoid@3.3.16: {}
 
   negotiator@1.0.0: {}
 
@@ -9658,9 +9655,9 @@ snapshots:
     dependencies:
       find-up: 3.0.0
 
-  postcss-nested@6.2.0(postcss@8.5.16):
+  postcss-nested@6.2.0(postcss@8.5.23):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.23
       postcss-selector-parser: 6.1.4
 
   postcss-selector-parser@6.1.4:
@@ -9673,15 +9670,9 @@ snapshots:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.14
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.16:
-    dependencies:
-      nanoid: 3.3.14
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -10209,7 +10200,7 @@ snapshots:
       node-fetch: 3.3.2
       open: 11.0.0
       ora: 8.2.0
-      postcss: 8.5.15
+      postcss: 8.5.23
       postcss-selector-parser: 7.1.4
       prompts: 2.4.2
       recast: 0.23.11
@@ -10715,7 +10706,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:
@@ -10729,7 +10720,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.5
-      postcss: 8.5.16
+      postcss: 8.5.23
       rolldown: 1.1.5
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,9 +9,10 @@ overrides:
   esbuild: ">=0.28.1"
   # The packages below are transitive deps with open security advisories
   # (GHSA-frvp-7c67-39w9, GHSA-3jxr-9vmj-r5cp, GHSA-v2hh-gcrm-f6hx,
-  # GHSA-hmw2-7cc7-3qxx, GHSA-w62v-xxxg-mg59, GHSA-52cp-r559-cp3m); all reach
-  # us via dev tooling (shadcn CLI and friends). The lockfile holds a single
-  # major of each, so a blanket floor at the first patched release is safe.
+  # GHSA-hmw2-7cc7-3qxx, GHSA-w62v-xxxg-mg59, GHSA-52cp-r559-cp3m,
+  # GHSA-r28c-9q8g-f849); all reach us via dev tooling (shadcn CLI, vite,
+  # astro, and friends). The lockfile holds a single major of each, so a
+  # blanket floor at the first patched release is safe.
   # @hono/node-server 2.x is a major bump, but its dependent
   # (@modelcontextprotocol/sdk) accepts "^1.19.9 || ^2.0.5" as of 1.30.0.
   # fast-uri and js-yaml use caret ranges to stay on the major their
@@ -22,6 +23,7 @@ overrides:
   form-data: ">=4.0.6"
   hono: ">=4.12.27"
   js-yaml: "^4.3.0"
+  postcss: ">=8.5.18"
 
 # systeminformation is a transitive dep (shadcn -> @dotenvx/dotenvx) whose 5.31.8
 # release landed in our lockfile <24h after publish. Exempt only this reviewed


### PR DESCRIPTION
## What changed

Resolves the one remaining Dependabot alert: postcss <= 8.5.17 (GHSA-r28c-9q8g-f849, source-map path traversal via `sourceMappingURL` disclosing arbitrary `.map` files), which surfaced right after #148 merged.

Both lockfile copies of postcss (8.5.15, 8.5.16) are transitive build-time dependencies of vite and astro, so this extends the existing security override block in pnpm-workspace.yaml with `postcss: ">=8.5.18"` — both now resolve to 8.5.23, within the 8.x major.

## Verification

- `just web-typecheck web-test web-build docs-typecheck docs-artifacts-check` all pass (the postcss consumers are the web and docs build pipelines; the Python runtime is untouched, so no e2e run was needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)