### PR TITLE
fix(deps): raise js-yaml floor to 4.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   form-data: '>=4.0.6'
   hono: '>=4.12.34'
   ip-address: '>=10.3.1'
-  js-yaml: ^4.3.0
+  js-yaml: ^4.3.1
   postcss: '>=8.5.18'
   undici: ^7.29.0
 
@@ -3443,8 +3443,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsdom@27.4.0:
@@ -5281,7 +5281,7 @@ snapshots:
   '@apidevtools/json-schema-ref-parser@13.0.5':
     dependencies:
       '@types/json-schema': 7.0.15
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
 
   '@asamuzakjp/css-color@4.1.2':
     dependencies:
@@ -5372,7 +5372,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.3.1
@@ -5484,7 +5484,7 @@ snapshots:
       hast-util-to-string: 3.0.1
       hastscript: 9.0.1
       i18next: 26.3.6(typescript@5.9.3)
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       klona: 2.0.6
       magic-string: 0.30.21
       mdast-util-directive: 3.1.0
@@ -7590,7 +7590,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 1.1.0
       magicast: 0.5.3
@@ -7838,7 +7838,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
@@ -8775,7 +8775,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,8 @@ overrides:
   # GHSA-r28c-9q8g-f849, GHSA-rgw5-rvv9-x895, GHSA-7p8r-x3mc-p8w7,
   # GHSA-8j4g-w8fx-2239, GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh,
   # GHSA-22jq-vg5j-6vgg, GHSA-4cwx-7wf7-3272, GHSA-8xcm-r25x-g524,
-  # GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5);
+  # GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5,
+  # GHSA-5p4m-2wfm-xmqj);
   # all reach us via dev tooling (shadcn CLI, vite, astro, and friends)
   # or, for ip-address, via express-rate-limit. The lockfile holds a
   # single major of each, so a blanket floor at the first patched
@@ -29,7 +30,7 @@ overrides:
   form-data: ">=4.0.6"
   hono: ">=4.12.34"
   ip-address: ">=10.3.1"
-  js-yaml: "^4.3.0"
+  js-yaml: "^4.3.1"
   postcss: ">=8.5.18"
   undici: "^7.29.0"
 


### PR DESCRIPTION
## Summary

Resolves the one open Dependabot alert: js-yaml >= 4.0.0, < 4.3.1 (GHSA-5p4m-2wfm-xmqj, high — quadratic CPU consumption in `!!omap` resolution, CVE-2026-59870 fix not backported).

js-yaml reaches ParseHawk only through dev tooling and already sits in the security override block in `pnpm-workspace.yaml` with a caret range; the floor moves from `^4.3.0` to `^4.3.1`, staying on the 4.x major its dependents declare. The lockfile resolves to js-yaml 4.3.1.

## Verification

- `pnpm install` + `pnpm -r build` — docs and web both build cleanly

No Python or runtime code path is affected, so the local runtime verification (`parsehawk restart` + `just e2e`) was not rerun for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

#152 