### PR TITLE
fix(deps): force nanoid to a patched release

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   hono: '>=4.12.34'
   ip-address: '>=10.3.1'
   js-yaml: ^4.3.1
+  nanoid: ^3.3.18
   postcss: '>=8.5.18'
   undici: ^7.29.0
 
@@ -3870,8 +3871,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9442,7 +9443,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   negotiator@1.0.0: {}
 
@@ -9674,7 +9675,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,16 +14,16 @@ overrides:
   # GHSA-8j4g-w8fx-2239, GHSA-mwp4-54f8-5fhr, GHSA-4xrf-jv44-h6hh,
   # GHSA-22jq-vg5j-6vgg, GHSA-4cwx-7wf7-3272, GHSA-8xcm-r25x-g524,
   # GHSA-v3r7-h72x-cjcm, GHSA-jr45-8vmc-qm54, GHSA-m8rv-5g2x-5cg5,
-  # GHSA-5p4m-2wfm-xmqj);
+  # GHSA-5p4m-2wfm-xmqj, GHSA-2v37-7h3g-55p8);
   # all reach us via dev tooling (shadcn CLI, vite, astro, and friends)
   # or, for ip-address, via express-rate-limit. The lockfile holds a
   # single major of each, so a blanket floor at the first patched
   # release is safe.
   # @hono/node-server 2.x is a major bump, but its dependent
   # (@modelcontextprotocol/sdk) accepts "^1.19.9 || ^2.0.5" as of 1.30.0.
-  # fast-uri, js-yaml, and undici use caret ranges to stay on the major
-  # their dependents (ajv, @dotenvx/dotenvx, and friends) actually
-  # declare.
+  # fast-uri, js-yaml, nanoid, and undici use caret ranges to stay on
+  # the major their dependents (ajv, postcss, @dotenvx/dotenvx, and
+  # friends) actually declare.
   "@hono/node-server": ">=2.0.5"
   brace-expansion: ">=5.0.9"
   fast-uri: "^3.1.5"
@@ -31,6 +31,7 @@ overrides:
   hono: ">=4.12.34"
   ip-address: ">=10.3.1"
   js-yaml: "^4.3.1"
+  nanoid: "^3.3.18"
   postcss: ">=8.5.18"
   undici: "^7.29.0"
 


### PR DESCRIPTION
## Summary

Resolves the one open Dependabot alert: nanoid < 3.3.18 (GHSA-2v37-7h3g-55p8, high — custom generators can loop indefinitely when size is zero).

The lockfile's only copy of nanoid is a transitive build-time dependency of postcss. It joins the security override block in `pnpm-workspace.yaml` with a caret floor of `^3.3.18`, staying on the 3.x major postcss declares. The lockfile resolves to nanoid 3.3.18.

## Verification

- `pnpm install` + `pnpm -r build` — docs and web both build cleanly

No Python or runtime code path is affected, so the local runtime verification (`parsehawk restart` + `just e2e`) was not rerun for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)